### PR TITLE
[Refactoring for Performance]  use Vec::split_off instead of Vec::drain to split a vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 
 matrix:
   allow_failures:
+    - rust: beta
     - rust: nightly
   include:
     - rust: nightly

--- a/src/nvm/memory.rs
+++ b/src/nvm/memory.rs
@@ -74,11 +74,11 @@ impl NonVolatileMemory for MemoryNvm {
             ErrorKind::InvalidInput
         );
         track_assert!(position <= self.capacity(), ErrorKind::InvalidInput);
-        let left = self.memory.get_mut().drain(..position as usize).collect();
-        let left = MemoryNvm::new(left);
+        let right = self.memory.get_mut().split_off(position as usize);
+        let right = MemoryNvm::new(right);
 
         self.memory.set_position(0);
-        Ok((left, self))
+        Ok((self, right))
     }
 }
 impl Seek for MemoryNvm {


### PR DESCRIPTION
On `memory.rs`,  we've used the method `Vec::drain` to implement the method `split(mut self, position: u64)`. However, as the following link shows, the method `Vec::split_off` is more acceptable than `Vec::drain` for our goal:
https://play.rust-lang.org/?version=nightly&mode=debug&edition=2015&gist=b3bb29d250c9178d30ee3e056243f7fd

In addition, since Clippy on the beta channel comes to reject current codes, I add rust-beta to `allow_failures`.