### PR TITLE
If file open operations fail, infer and print error messages.

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -453,7 +453,7 @@ mod tests {
             let device = DeviceBuilder::new().spawn(|| Ok(storage));
             let d = device.handle();
             let _ = execute(d.request().wait_for_running().list());
-            track!(execute(d.request().put(id(1234), embedded_data(b"hoge"))));
+            track!(execute(d.request().put(id(1234), embedded_data(b"hoge"))))?;
             assert_eq!(v, nvm.to_bytes()); // ジャーナルバッファ上に値があり、実際に書き込まれていない
         }
 
@@ -472,7 +472,7 @@ mod tests {
                 d.request()
                     .journal_sync()
                     .put(id(1234), embedded_data(b"hoge"))
-            ));
+            ))?;
             assert_ne!(v, nvm.to_bytes()); // `journal_sync` により、実際に書き込まれている
         }
 

--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -138,17 +138,16 @@ impl FileNvmBuilder {
                 // failed to file open
                 return track!(
                     open_result,
-                    format!("We failed to create the file {:?}.", filepath.as_ref())
+                    "We failed to create the file {:?}.",
+                    filepath.as_ref()
                 );
             } else {
                 // `do_create == false` means to open an existing file;
                 // however, now the file `filepath` does not exist.
                 return track!(
                     open_result,
-                    format!(
-                        "The file {:?} does not exist and failed to open it.",
-                        filepath.as_ref()
-                    )
+                    "The file {:?} does not exist and failed to open it.",
+                    filepath.as_ref()
                 );
             }
         }
@@ -161,7 +160,8 @@ impl FileNvmBuilder {
         if file.is_err() {
             return track!(
                 file,
-                format!("We cannot open the file {:?}.", filepath.as_ref())
+                "We cannot open the file {:?}.",
+                filepath.as_ref()
             );
         }
 
@@ -172,10 +172,8 @@ impl FileNvmBuilder {
             if file.is_err() {
                 return track!(
                     file,
-                    format!(
-                        "We cannot open the file {:?} with O_DIRECT.",
-                        filepath.as_ref()
-                    )
+                    "We cannot open the file {:?} with O_DIRECT.",
+                    filepath.as_ref()
                 );
             }
         }


### PR DESCRIPTION
This PR is an ad-hoc patch for the two issues: https://github.com/frugalos/cannyls/issues/9, https://github.com/frugalos/frugalos/issues/36