### PR TITLE
Ensure that the parent directories of a file exist

### DIFF
--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -373,6 +373,17 @@ mod tests {
     use storage::{StorageHeader, MAJOR_VERSION, MINOR_VERSION};
 
     #[test]
+    fn create_parent_directories_is_idempotent() -> TestResult {
+        let dir = track_io!(TempDir::new("cannyls_test"))?;
+        let filepath = dir.path().join("dir1").join("file1");
+
+        assert!(create_parent_directories(&filepath).is_ok());
+        assert!(create_parent_directories(&filepath).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
     fn create_parent_directories_creates_parent_directories() -> TestResult {
         let root = track_io!(TempDir::new("cannyls_test1"))?.into_path();
         let sub_dirs = vec!["dir1", "dir2", "dir3"];

--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -373,6 +373,30 @@ mod tests {
     use storage::{StorageHeader, MAJOR_VERSION, MINOR_VERSION};
 
     #[test]
+    fn create_parent_directories_creates_parent_directories() -> TestResult {
+        let root = track_io!(TempDir::new("cannyls_test1"))?;
+        let filepath = root.path().join("dir1").join("dir2").join("dir3").join("1.lusf");
+        create_parent_directories(filepath)?;
+        let mut dir = root.into_path();
+        for sub_dir in vec!["dir1", "dir2", "dir3"] {
+            dir = dir.join(sub_dir);
+            assert!(dir.exists());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn create_parent_directories_does_nothing_if_there_is_no_parent() -> TestResult {
+        let dir = track_io!(TempDir::new("cannyls_test1"))?;
+        let mut parent = dir.as_ref();
+        while let Some(p) = parent.parent() {
+            parent = p;
+        };
+        assert!(create_parent_directories(parent).is_ok());
+        Ok(())
+    }
+
+    #[test]
     fn open_and_create_works() -> TestResult {
         let dir = track_io!(TempDir::new("cannyls_test"))?;
         let capacity = 10 * 1024;

--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -374,14 +374,26 @@ mod tests {
 
     #[test]
     fn create_parent_directories_creates_parent_directories() -> TestResult {
-        let root = track_io!(TempDir::new("cannyls_test1"))?;
-        let filepath = root.path().join("dir1").join("dir2").join("dir3").join("1.lusf");
+        let root = track_io!(TempDir::new("cannyls_test1"))?.into_path();
+        let sub_dirs = vec!["dir1", "dir2", "dir3"];
+        let filepath = root.join("dir1").join("dir2").join("dir3").join("1.lusf");
+
+        // 作成前は存在しない
+        let mut dir = root.clone();
+        for sub_dir in &sub_dirs {
+            dir = dir.join(sub_dir);
+            assert!(!dir.exists());
+        }
+
         create_parent_directories(filepath)?;
-        let mut dir = root.into_path();
-        for sub_dir in vec!["dir1", "dir2", "dir3"] {
+
+        // 作成後は存在する
+        let mut dir = root;
+        for sub_dir in &sub_dirs {
             dir = dir.join(sub_dir);
             assert!(dir.exists());
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
This resolves https://github.com/frugalos/cannyls/issues/14.

`create_if_absent` method should create the parent directories of a file before creating the file because `create` method does so.

Note: Builds triggered by this PR may fail due to https://github.com/frugalos/cannyls/issues/15.