### PR TITLE
[WIP] NvmBufferのreadの振る舞いに関するコメントとテストを追加

### DIFF
--- a/src/storage/journal/nvm_buffer.rs
+++ b/src/storage/journal/nvm_buffer.rs
@@ -391,7 +391,7 @@ mod tests {
 
         let mut read1 = vec![0; 3];
         track_io!(buffer.seek(SeekFrom::Start(0)))?;
-        let len = track_io!(buffer.read(&mut read))?;
+        let len = track_io!(buffer.read(&mut read1))?;
         assert_eq!(len, 3);
         assert_eq!(read1, data);
 
@@ -402,7 +402,7 @@ mod tests {
 
         let mut read2 = vec![0; 3];
         track_io!(buffer.seek(SeekFrom::Start(0)))?;
-        let len = track_io!(buffer.read(&mut read))?;
+        let len = track_io!(buffer.read(&mut read2))?;
         assert_eq!(len, 3);
         assert_eq!(read1, read2);
 


### PR DESCRIPTION
`nvm_buffer`モジュールで定義している`JournalNvmBuffer`
https://github.com/frugalos/cannyls/blob/b908df654749c41bb6e9ed594e943494fd8c20a3/src/storage/journal/nvm_buffer.rs#L13-L57
について、`read`メソッドの振る舞いの意図を明確にするためのコメントとテストを追加した。



