### PR TITLE
Fix cannyls for the issue of PR23

### DIFF
--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -487,7 +487,7 @@ mod tests {
         let mut parent = dir.as_ref();
         while let Some(p) = parent.parent() {
             parent = p;
-        };
+        }
         assert!(create_parent_directories(parent).is_ok());
         Ok(())
     }


### PR DESCRIPTION
# 概要
#23 で論じているjournalのhead positionの更新タイミングが遅い問題へのパッチ

ring_bufferでは 不変条件 `unreleased_head <= head <= tail` を守っている。
https://github.com/frugalos/cannyls/blob/b908df654749c41bb6e9ed594e943494fd8c20a3/src/storage/journal/ring_buffer.rs#L199-L203
しかし実際には永続化されている`head_position`も含めて
`head_position <= unreleased_head <= head <= tail`
を守らなくてはならない。

# 解決策
永続化の回数（ディスクへのアクセス回数）を可能な限り減らすことを念頭においている。
そこで、最後に永続化したhead positionに対してデータを書き込もうとした際に、それを検知し、書き込みの前にhead positionをその段階のunreleased headで更新するようにした。

最後に永続化したhead positionは `written_header_pos` メンバを使って行っている。
検知については、`does_enqueue_overwrite` メソッドを使って行っている。