### PR TITLE
PR23を解決するために、unreleased_headに対する操作を変更した

### DIFF
--- a/src/storage/journal/region.rs
+++ b/src/storage/journal/region.rs
@@ -215,7 +215,7 @@ where
         // 上のloopを抜けた後では
         // `unreleased_head`と`head`の間のエントリは全て再配置済みである。
         // そこで現在の`head`の値をジャーナルエントリ開始位置として永続化し、
-        // `unreheased_head`も更新する。
+        // `unreleased_head`も更新する。
         let ring_buffer_head = self.ring_buffer.head();
         track!(self.write_journal_header(ring_buffer_head))?;
 
@@ -223,7 +223,7 @@ where
     }
 
     /// `ring_buffer_head`をジャーナルエントリ開始位置として永続化し、
-    /// `unreheased_head`を`ring_buffer_head`に移動する。
+    /// `unreleased_head`を`ring_buffer_head`に移動する。
     fn write_journal_header(&mut self, ring_buffer_head: u64) -> Result<()> {
         let header = JournalHeader { ring_buffer_head };
         track!(self.header_region.write_header(&header))?;
@@ -309,7 +309,7 @@ where
         // GCキューが空 `gc_queue.is_empty() == true`
         // すなわち `unreleased_head` と `head` の間のレコード群は全て再配置済みであるため、
         // 現在のhead位置をジャーナルエントリの開始位置として永続化し、
-        // `unreheased_head`の位置も更新する。
+        // `unreleased_head`の位置も更新する。
         let ring_buffer_head = self.ring_buffer.head();
         track!(self.write_journal_header(ring_buffer_head))?;
 

--- a/src/storage/journal/region.rs
+++ b/src/storage/journal/region.rs
@@ -182,17 +182,6 @@ where
                 break;
             }
         }
-        if let Some(next) = self.gc_queue.front() {
-            // gc_queueにまだエントリがある場合には
-            // そのエントリ以降が処理対象になるのでunreleased_headを移動させる。
-            self.ring_buffer.release_bytes_until(next.start.as_u64());
-        } else {
-            // gc_queueにエントリがない場合には
-            // GC対象になるエントリが存在しないということなので
-            // unreleased_head = head が成立するようにする。
-            let head = self.ring_buffer.head();
-            self.ring_buffer.release_bytes_until(head);
-        }
 
         Ok(())
     }
@@ -222,13 +211,23 @@ where
             }
         }
 
-        // エントリの回収が行われてhead位置が変わっているので
-        // ストレージのヘッダ領域を更新する
-        let header = JournalHeader {
-            ring_buffer_head: self.ring_buffer.head(),
-        };
-        track!(self.header_region.write_header(&header))?;
+        // `gc_all_entries_in_queue`は`gc_queue`が空になるまで処理を行うため、
+        // 上のloopを抜けた後では
+        // `unreleased_head`と`head`の間のエントリは全て再配置済みである。
+        // そこで現在の`head`の値をジャーナルエントリ開始位置として永続化し、
+        // `unreheased_head`も更新する。
+        let ring_buffer_head = self.ring_buffer.head();
+        track!(self.write_journal_header(ring_buffer_head))?;
 
+        Ok(())
+    }
+
+    /// `ring_buffer_head`をジャーナルエントリ開始位置として永続化し、
+    /// `unreheased_head`を`ring_buffer_head`に移動する。
+    fn write_journal_header(&mut self, ring_buffer_head: u64) -> Result<()> {
+        let header = JournalHeader { ring_buffer_head };
+        track!(self.header_region.write_header(&header))?;
+        self.ring_buffer.release_bytes_until(ring_buffer_head);
         Ok(())
     }
 
@@ -305,7 +304,14 @@ where
     ///
     /// 必要に応じて、ジャーナルヘッダの更新も行う.
     fn fill_gc_queue(&mut self) -> Result<()> {
-        debug_assert!(self.gc_queue.is_empty());
+        assert!(self.gc_queue.is_empty());
+
+        // GCキューが空 `gc_queue.is_empty() == true`
+        // すなわち `unreleased_head` と `head` の間のレコード群は全て再配置済みであるため、
+        // 現在のhead位置をジャーナルエントリの開始位置として永続化し、
+        // `unreheased_head`の位置も更新する。
+        let ring_buffer_head = self.ring_buffer.head();
+        track!(self.write_journal_header(ring_buffer_head))?;
 
         if self.ring_buffer.is_empty() {
             return Ok(());
@@ -316,10 +322,6 @@ where
             self.gc_queue.push_back(entry);
         }
 
-        if let Some(ring_buffer_head) = self.gc_queue.front().map(|x| x.start.as_u64()) {
-            let header = JournalHeader { ring_buffer_head };
-            track!(self.header_region.write_header(&header))?;
-        }
         self.metrics
             .gc_enqueued_records
             .add_u64(self.gc_queue.len() as u64);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -700,43 +700,43 @@ mod tests {
 
         let nvm = track!(FileNvm::create(
             dir.path().join("test.lusf"),
-            BlockSize::min().ceil_align(5120 * 100)
+            BlockSize::min().ceil_align(1024 * 400)
         ))?;
         let mut storage = track!(StorageBuilder::new().journal_region_ratio(0.01).create(nvm))?;
         storage.set_automatic_gc_mode(false);
 
         {
             let header = storage.header();
-            assert_eq!(header.journal_region_size, 5120);
+            assert_eq!(header.journal_region_size, 4096);
         }
 
-        for i in 0..80 {
+        for i in 0..60 {
             assert!(storage.put(&id(&i.to_string()), &zeroed_data(42))?);
         }
-        for i in 0..50 {
+        for i in 0..20 {
             assert!(storage.delete(&id(&i.to_string()))?);
         }
         {
             let snapshot = track!(storage.journal_snapshot())?;
             assert_eq!(snapshot.unreleased_head, 0);
             assert_eq!(snapshot.head, 0);
-            assert_eq!(snapshot.tail, 3290);
+            assert_eq!(snapshot.tail, 2100);
         }
 
         track!(storage.journal_gc())?;
         {
             let snapshot = track!(storage.journal_snapshot())?;
-            assert_eq!(snapshot.unreleased_head, 3290);
-            assert_eq!(snapshot.head, 3290);
-            assert_eq!(snapshot.tail, 4130);
+            assert_eq!(snapshot.unreleased_head, 2100);
+            assert_eq!(snapshot.head, 2100);
+            assert_eq!(snapshot.tail, 3220);
         }
 
         track!(storage.journal_gc())?;
         {
             let snapshot = track!(storage.journal_snapshot())?;
-            assert_eq!(snapshot.unreleased_head, 4130);
-            assert_eq!(snapshot.head, 4130);
-            assert_eq!(snapshot.tail, 392);
+            assert_eq!(snapshot.unreleased_head, 3220);
+            assert_eq!(snapshot.head, 3220);
+            assert_eq!(snapshot.tail, 784);
         }
 
         Ok(())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -744,13 +744,16 @@ mod tests {
 
     #[test]
     /*
-     * GCによりunreleased_headの位置が更新されても、
-     * その新しいunreleased_headをディスクに永続化する前にstorageが終了してしまった場合、
-     * storageの再起動時に古いunreleased_head位置を読み込んでしまう。
-     * 古いunreleased_head位置にはレコード先頭とは限らないデータが書き込まれているため
-     * 再起動時にエラーになってしまう。
+     * cannyls 0.9.2以前では
+     * PR23 https://github.com/frugalos/cannyls/pull/23
+     * が指摘する問題によりpanicしていた。
+     * その問題が発生しないことを確認するためのテスト。
+     * （発生していた問題というのは、
+     * ジャーナルヘッドに永続化されている`head_position`の値と
+     * これに対応するメモリ上のフィールド`unreleased_head`の値にズレが生じることに起因する。
+     * 詳細についてはPR23を参考にされたい。）
      */
-    fn unintended_overwriting_head_position_makes_storage_corrupted() -> TestResult {
+    fn confirm_that_the_problem_of_pr23_is_resolved() -> TestResult {
         let dir = track_io!(TempDir::new("cannyls_test"))?;
 
         let nvm = track!(FileNvm::create(
@@ -815,35 +818,40 @@ mod tests {
             assert_eq!(snapshot.head, 3198);
             assert_eq!(snapshot.tail, 3198);
         }
-        // ここまでにunreleased_headの永続化は行っていないので
-        // ジャーナル領域のhead positionフィールドは位置33を指したままである。
-        // （＝ この状態で再起動が行われると、ジャーナルレコード領域の33を先頭レコードとして読み込む）
+        /*
+         * ジャーナル領域のhead positionはunreleased_headの値と常に等しいため
+         * この段階ではジャーナル領域のhead positionフィールドは位置3198を指している。
+         * これ以降ではPR23と同様に位置33に対して値42を書き込み、不正なtagとして認識させることを試みるが、
+         * cannyls 0.9.2以降では問題にならない。
+         *
+         * 注意:
+         *  cannyls 0.9.2以前では、head positionがこの段階で位置3198を指す保証はない。
+         *  実際として、PR23の段階では古いunreleased_headの値33を指していた。
+         */
 
-        // tailを一周させ、head positionフィールドの指す位置33に対して値42を上書きし、状態(C)を作る。
+        // tailを一周させ、位置33に対して値42を書き込む。
         let vec: Vec<u8> = vec![42; 2000];
         let lump_data = track!(LumpData::new_embedded(vec))?;
         track!(storage.put(&test_lump_id, &lump_data))?;
         {
             // (C)
-            // journal recordsの先頭位置は33として永続化されているが、
-            // その位置33の周辺を値`42`で上書きした状態。
+            // 位置33の周辺を値`42`で上書きした状態。
             let snapshot = storage.journal_snapshot().unwrap();
             assert_eq!(snapshot.unreleased_head, 3198);
             assert_eq!(snapshot.head, 3198);
             assert_eq!(snapshot.tail, 2023);
         }
 
-        // 最新のunreleased_head 3198をhead positionフィールドに永続化する「前に」
-        // storageがcrashする状態を模倣する。
+        // storageがcrashして再起動する操作群を模倣する。
         std::mem::drop(storage);
-        // 再起動を試みる
         let nvm = track!(FileNvm::open(dir.path().join("test.lusf")))?;
-        // journal recordsの先頭位置に大量の42を書き込んだため
-        // これがtagとして認識されてしまい、`ErrorKind::StorageCorrupted`エラーが発生する。
-        // 注意: 42はtagではない
-        // https://github.com/frugalos/cannyls/wiki/Storage-Format
-        let error = track!(Storage::open(nvm)).unwrap_err();
-        assert!(*error.kind() == ErrorKind::StorageCorrupted);
+        let mut storage = track!(Storage::open(nvm))?;
+        {
+            let snapshot = storage.journal_snapshot().unwrap();
+            assert_eq!(snapshot.unreleased_head, 3198);
+            assert_eq!(snapshot.head, 3198);
+            assert_eq!(snapshot.tail, 2023);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
# 本PRの目的
[PR23](https://github.com/frugalos/cannyls/pull/23)で指摘された、これまでのcannylsがcrashしてしまう現象を解決する。

# 本PRによる主な変更
[PR23](https://github.com/frugalos/cannyls/pull/23)の指摘する問題点は、ジャーナルレコード群の開始位置を表す以下二つの値が異なる瞬間が発生するというものである:
1. cannylsのジャーナルヘッドに永続化されている `header_position`
2. cannylsのメモリ上にある `unreleased_head`

本PRでは、常に`header_position == unreleased_head`という関係が成り立つように`unreleased_head`の更新タイミングを変更したものである。
この変更により、PR23で指摘されている、本来上書きされるべきでない`header_position`に対する上書きが防がれ、PR23が解決される。

## 技術的な詳細
これまで、`unreleased_head`はGCでレコードを一つずつ操作するたびに更新されていた。
これによって、一時的（正確には`fill_gc_queue`の際）に `head_position == unreleased_head`が成立しても、徐々に乖離していくという問題があった。
そこで本PRではGCでレコードを操作するたびに`unreleased_head`を更新しないようにした。これによって`head_position == unreleased_head`が常に成立する。

## 考えられる問題点
`unreleased_head`が細かく更新されなくなったために、
https://github.com/frugalos/cannyls/blob/b908df654749c41bb6e9ed594e943494fd8c20a3/src/storage/journal/ring_buffer.rs#L190-L216
の部分でこれまでより `ErrorKind::StorageFull` が発生する可能性が増える。

# 本PRの主でない変更
`unreleased_head`の挙動が変わったため、あるテストコードがfailするようになりました。
これにも対応しています。