### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cannyls"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["The FrugalOS Developers"]
 description = "Embedded persistent key-value storage optimized for random-access workload and huge-capacity HDD"
 homepage = "https://github.com/frugalos/cannyls"


### PR DESCRIPTION
CannyLSのパッチバージョンを上げて、0.9.2 → 0.9.3 とするためのPR

別のPR https://github.com/frugalos/cannyls/pull/25 による
1. インタフェース変更なしの
2. バグ修正（ディスクに永続化される `head_position` と、メモリ上にある `unreleased_head` の値を常に一致させる修正）

を行ったことに伴うものです。