### PR TITLE
issue27のパッチ

### DIFF
--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -487,7 +487,7 @@ mod tests {
         let mut parent = dir.as_ref();
         while let Some(p) = parent.parent() {
             parent = p;
-        };
+        }
         assert!(create_parent_directories(parent).is_ok());
         Ok(())
     }

--- a/src/storage/journal/mod.rs
+++ b/src/storage/journal/mod.rs
@@ -1,6 +1,6 @@
 pub use self::header::{JournalHeader, JournalHeaderRegion};
 pub use self::nvm_buffer::JournalNvmBuffer;
-pub use self::options::JournalRegionOptions;
+pub use self::options::{JournalBufferOptions, JournalRegionOptions};
 pub use self::record::{JournalEntry, JournalRecord};
 pub use self::region::JournalRegion;
 

--- a/src/storage/journal/options.rs
+++ b/src/storage/journal/options.rs
@@ -3,11 +3,12 @@ use block::BlockSize;
 /// ジャーナル領域の挙動を調整するためのパラメータ群.
 ///
 /// 各オプションの説明は`StorageBuilder'のドキュメントを参照のこと.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct JournalRegionOptions {
     pub gc_queue_size: usize,
     pub sync_interval: usize,
     pub block_size: BlockSize,
+    pub buffer_options: JournalBufferOptions,
 }
 impl Default for JournalRegionOptions {
     fn default() -> Self {
@@ -15,6 +16,21 @@ impl Default for JournalRegionOptions {
             gc_queue_size: 0x1000,
             sync_interval: 0x1000,
             block_size: BlockSize::min(),
+            buffer_options: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct JournalBufferOptions {
+    pub safe_flush: bool,
+    pub safe_enqueue: bool,
+}
+impl Default for JournalBufferOptions {
+    fn default() -> Self {
+        JournalBufferOptions {
+            safe_flush: false,
+            safe_enqueue: false,
         }
     }
 }

--- a/src/storage/journal/region.rs
+++ b/src/storage/journal/region.rs
@@ -80,8 +80,12 @@ where
 
         let mut header_region = JournalHeaderRegion::new(header_nvm, block_size);
         let header = track!(header_region.read_header())?;
-        let ring_buffer =
-            JournalRingBuffer::new(ring_buffer_nvm, header.ring_buffer_head, metric_builder);
+        let ring_buffer = JournalRingBuffer::new(
+            ring_buffer_nvm,
+            header.ring_buffer_head,
+            options.buffer_options,
+            metric_builder,
+        );
 
         let metrics = JournalRegionMetrics::new(metric_builder, ring_buffer.metrics().clone());
         let mut journal = JournalRegion {

--- a/src/storage/journal/ring_buffer.rs
+++ b/src/storage/journal/ring_buffer.rs
@@ -2,7 +2,7 @@ use prometrics::metrics::MetricBuilder;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 
 use super::record::{EMBEDDED_DATA_OFFSET, END_OF_RECORDS_SIZE};
-use super::{JournalEntry, JournalNvmBuffer, JournalRecord};
+use super::{JournalBufferOptions, JournalEntry, JournalNvmBuffer, JournalRecord};
 use lump::LumpId;
 use metrics::JournalQueueMetrics;
 use nvm::NonVolatileMemory;
@@ -34,6 +34,8 @@ pub struct JournalRingBuffer<N: NonVolatileMemory> {
     tail: u64,
 
     metrics: JournalQueueMetrics,
+
+    safe_enqueue: bool,
 }
 impl<N: NonVolatileMemory> JournalRingBuffer<N> {
     pub fn head(&self) -> u64 {
@@ -51,15 +53,21 @@ impl<N: NonVolatileMemory> JournalRingBuffer<N> {
     }
 
     /// `JournalRingBuffer`インスタンスを生成する.
-    pub fn new(nvm: N, head: u64, metric_builder: &MetricBuilder) -> Self {
+    pub fn new(
+        nvm: N,
+        head: u64,
+        options: JournalBufferOptions,
+        metric_builder: &MetricBuilder,
+    ) -> Self {
         let metrics = JournalQueueMetrics::new(metric_builder);
         metrics.capacity_bytes.set(nvm.capacity() as f64);
         JournalRingBuffer {
-            nvm: JournalNvmBuffer::new(nvm),
+            nvm: JournalNvmBuffer::new(nvm, options.safe_flush),
             unreleased_head: head,
             head,
             tail: head,
             metrics,
+            safe_enqueue: options.safe_enqueue,
         }
     }
 
@@ -108,10 +116,21 @@ impl<N: NonVolatileMemory> JournalRingBuffer<N> {
         track!(self.nvm.sync())
     }
 
+    pub fn enqueue<B: AsRef<[u8]>>(
+        &mut self,
+        record: &JournalRecord<B>,
+    ) -> Result<Option<(LumpId, JournalPortion)>> {
+        if self.safe_enqueue {
+            self.safe_enqueue(record)
+        } else {
+            self.fast_enqueue(record)
+        }
+    }
+
     /// レコードをジャーナルの末尾に追記する.
     ///
     /// レコードが`JournalRecord::Embed`だった場合には、データを埋め込んだ位置を結果として返す.
-    pub fn enqueue<B: AsRef<[u8]>>(
+    fn fast_enqueue<B: AsRef<[u8]>>(
         &mut self,
         record: &JournalRecord<B>,
     ) -> Result<Option<(LumpId, JournalPortion)>> {
@@ -146,6 +165,70 @@ impl<N: NonVolatileMemory> JournalRingBuffer<N> {
         track!(JournalRecord::EndOfRecords::<[_; 0]>.write_to(&mut self.nvm))?;
 
         // 5. 埋め込みPUTの場合には、インデックスに位置情報を返す
+        if let JournalRecord::Embed(ref lump_id, ref data) = *record {
+            let portion = JournalPortion {
+                start: Address::from_u64(prev_tail + EMBEDDED_DATA_OFFSET as u64).unwrap(),
+                len: data.as_ref().len() as u16,
+            };
+            Ok(Some((*lump_id, portion)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// レコードをジャーナルの末尾に、安全に、追記する.
+    ///
+    /// レコードが`JournalRecord::Embed`だった場合には、データを埋め込んだ位置を結果として返す.
+    fn safe_enqueue<B: AsRef<[u8]>>(
+        &mut self,
+        record: &JournalRecord<B>,
+    ) -> Result<Option<(LumpId, JournalPortion)>> {
+        // GoToFrontレコードを書き出す場所を覚えるための変数
+        let mut pos_for_gotofront = None;
+
+        // 1. 十分な空き領域が存在するかをチェック
+        track!(self.check_free_space(record))?;
+
+        // 2. リングバッファの終端チェック
+        if self.will_overflow(record) {
+            // tail位置からでは空きがないので、先頭に戻って再試行
+            // 後で先頭から復帰するために場所を覚えておく
+            pos_for_gotofront = Some(self.tail);
+
+            self.metrics
+                .consumed_bytes_at_running
+                .add_u64(self.nvm.capacity() - self.tail);
+
+            // 先頭に移動した上で
+            // 再度、十分な空き領域が存在するかをチェック
+            self.tail = 0;
+            debug_assert!(!self.will_overflow(record));
+            track!(self.check_free_space(record))?;
+        }
+
+        // 3. レコードを書き込む
+        let prev_tail = self.tail;
+        track_io!(self.nvm.seek(SeekFrom::Start(self.tail)))?;
+        track!(record.write_to(&mut self.nvm))?;
+        self.metrics.enqueued_records_at_running.increment(record);
+
+        // 4. 終端を示すレコードも書き込む
+        self.tail = self.nvm.position(); // 次回の追記開始位置を保存 (`EndOfRecords`の直前)
+        self.metrics
+            .consumed_bytes_at_running
+            .add_u64(self.tail - prev_tail);
+        track!(JournalRecord::EndOfRecords::<[_; 0]>.write_to(&mut self.nvm))?;
+
+        // 5. GoToFrontを書き込む必要があれば、一度末尾までジャンプして書き込んだ後に戻ってくる。
+        // GoToFrontの書き出しを先に行ってしまうと、EndOfRecordsが存在しない状態が永続化される可能性がある。
+        if let Some(pos_for_gotofront) = pos_for_gotofront {
+            track!(self.nvm.sync())?; // 新しいEndOfRecordsの書き込みを先に永続化する。
+            track_io!(self.nvm.seek(SeekFrom::Start(pos_for_gotofront)))?;
+            track!(JournalRecord::GoToFront::<[_; 0]>.write_to(&mut self.nvm))?; // 古いEndOfRecordsに上書き
+            track_io!(self.nvm.seek(SeekFrom::Start(self.tail)))?;
+        }
+
+        // 6. 埋め込みPUTの場合には、インデックスに位置情報を返す
         if let JournalRecord::Embed(ref lump_id, ref data) = *record {
             let portion = JournalPortion {
                 start: Address::from_u64(prev_tail + EMBEDDED_DATA_OFFSET as u64).unwrap(),
@@ -364,7 +447,7 @@ mod tests {
     #[test]
     fn append_and_read_records() -> TestResult {
         let nvm = MemoryNvm::new(vec![0; 1024]);
-        let mut ring = JournalRingBuffer::new(nvm, 0, &MetricBuilder::new());
+        let mut ring = JournalRingBuffer::new(nvm, 0, Default::default(), &MetricBuilder::new());
 
         let records = vec![
             record_put("000", 30, 5),
@@ -397,7 +480,7 @@ mod tests {
     #[test]
     fn read_embedded_data() -> TestResult {
         let nvm = MemoryNvm::new(vec![0; 1024]);
-        let mut ring = JournalRingBuffer::new(nvm, 0, &MetricBuilder::new());
+        let mut ring = JournalRingBuffer::new(nvm, 0, Default::default(), &MetricBuilder::new());
 
         track!(ring.enqueue(&record_put("000", 30, 5)))?;
         track!(ring.enqueue(&record_delete("111")))?;
@@ -415,7 +498,7 @@ mod tests {
     #[test]
     fn go_round_ring_buffer() -> TestResult {
         let nvm = MemoryNvm::new(vec![0; 1024]);
-        let mut ring = JournalRingBuffer::new(nvm, 512, &MetricBuilder::new());
+        let mut ring = JournalRingBuffer::new(nvm, 512, Default::default(), &MetricBuilder::new());
         assert_eq!(ring.head, 512);
         assert_eq!(ring.tail, 512);
 
@@ -433,7 +516,7 @@ mod tests {
     #[test]
     fn full() -> TestResult {
         let nvm = MemoryNvm::new(vec![0; 1024]);
-        let mut ring = JournalRingBuffer::new(nvm, 0, &MetricBuilder::new());
+        let mut ring = JournalRingBuffer::new(nvm, 0, Default::default(), &MetricBuilder::new());
 
         let record = record_put("000", 1, 2);
         while ring.tail <= 1024 - record.external_size() as u64 {
@@ -464,7 +547,7 @@ mod tests {
     #[test]
     fn too_large_record() {
         let nvm = MemoryNvm::new(vec![0; 1024]);
-        let mut ring = JournalRingBuffer::new(nvm, 0, &MetricBuilder::new());
+        let mut ring = JournalRingBuffer::new(nvm, 0, Default::default(), &MetricBuilder::new());
 
         let record = record_embed("000", &vec![0; 997]);
         assert_eq!(record.external_size(), 1020);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -248,9 +248,9 @@ where
         // ジャーナル領域に範囲削除レコードを一つ書き込むため、一度のディスクアクセスが起こる。
         // 削除レコードを範囲分書き込むわけ *ではない* ため、複数回のディスクアクセスは発生しない。
         track!(self
-               .journal_region
-               .records_delete_range(&mut self.lump_index, range))?;
-        
+            .journal_region
+            .records_delete_range(&mut self.lump_index, range))?;
+
         for lump_id in &targets {
             if let Some(portion) = self.lump_index.remove(lump_id) {
                 self.metrics.delete_lumps.increment();
@@ -262,7 +262,7 @@ where
                     self.data_region.delete(portion);
                 }
             }
-        }        
+        }
 
         Ok(targets)
     }
@@ -522,9 +522,10 @@ mod tests {
 
         // マイナーバージョンを減らして、ヘッダを上書きする
         {
-            header.minor_version = header.minor_version.checked_sub(1).expect(
-                "このテストは`MINOR_VERSION >= 1`であることを前提としている",
-            );
+            header.minor_version = header
+                .minor_version
+                .checked_sub(1)
+                .expect("このテストは`MINOR_VERSION >= 1`であることを前提としている");
             let file = track_any_err!(OpenOptions::new().write(true).open(&path))?;
             track!(header.write_to(file))?;
         }


### PR DESCRIPTION
# このPRの狙い
異常終了するケースで、`EndOfRecords`（以下 *EoR* )が存在しないジャーナル領域が生じ、以降そのlusfファイルが読み込めなくなるというissue https://github.com/frugalos/cannyls/issues/27 を解決する。

*EoR* が消失する問題は、メモリ上のジャーナルバッファを永続化する処理が完了しない（＝途中で強制終了する）場合に起こりうる、ジャーナル領域が破壊される分かりやすい一例である。
こうしたジャーナル領域の破損の例としては、*EoR* の消失以外にも、特定のジャーナルレコードが中途半端に書き出されてしまい、再起動できなくなるといったこともある。

本PRは、ジャーナルバッファの書き出し処理を「安全に」行うことで、強制終了した場合にも正常なジャーナル領域に回復する、より一般的な解決を目指す。
より正確には、ジャーナルバッファの書き出し処理がatomicになるようにし、書き出しが完了してジャーナル領域が完全に更新されるか、または書き出しの途中で失敗した場合は書き出しを行う直前まで戻す。

# 本PRに関する前提知識
* Cannylsのジャーナル領域 https://github.com/frugalos/cannyls/wiki/Journal-Region
* ジャーナルレコード https://github.com/frugalos/cannyls/wiki/Storage-Format#3-2-ジャーナル領域-レコード部
* ジャーナル領域に対するメモリバッファ https://github.com/frugalos/cannyls/wiki/Journal-Memory-Buffer

# Issue27とは何か
Issue27は、大まかには次の二つの状況で *EoR* が消失することを表している:
## 状況1（ジャーナルバッファをメモリからdiskにflushする際の話）
```
...[recordA][EoR] => ジャーナルバッファの内容をflushする
...[recordA].......... => ジャーナルバッファの内容を全てflushしきる前にcrashしてEoRが消え去る
```
この場合には、ジャーナル領域に *EoR* が存在せず、ジャーナル領域がどこまでか認識できないため起動に失敗する。

## 状況2（ジャーナル領域の末尾に到達したので先頭までシークする際の話）
```
[recordA]...[recordX][EoR] => GoToFrontを書き込み、先頭にシークした後にrecordYを追加したい
[recordA]...[recordX][GoToFront] => GoToFrontは書き込んだが、recordYの書き込み前にcrash
```
この場合にも *EoR* が存在しないために、ジャーナル領域全体を認識できない。

# このPRでの上にあげた状況への対応
## 状況1について
メモリバッファの書き出し時に、*EoR*を上書きすることになるメモリバッファ先頭512バイトの書き出しを後回しにする。すなわち
1. 先頭512バイトより後ろを先に書き出す。
2. `sync`による永続化を行う。（この瞬間、Diskには古いEoRと新しいEoRの2つが存在する）
3. 最後に先頭512バイトを書き出す。（3の書き出しが、実際にDiskにreachすれば、古いEoRは消える）

さて、以下２つの点について説明したい:
a. EoRは2つ存在しても良いのか？
b. 先頭512バイトを特別扱いするのはなぜか？

a. については、EoRは2つ存在しても問題ない。Cannylsは再起動時に、Diskに永続化されているジャーナル先頭領域から順にエントリを取り出し、最初にEoRに到達したところで処理をやめる。従って、EoRが2つあったとしても正常に起動することはできる。
メモリバッファの書き出しに完全に成功した場合は、すなわち3. の書き出しまで完了したならば、ジャーナル領域は正常に更新されることになる。
一方で3.の書き出し完了まで到達しなかった場合は、古い*EoR*までをもってジャーナル領域と認識するが、これはメモリバッファの書き出しに成功しなかったことを考えると自然な挙動であるといえる。

先頭512バイトを特別扱いする理由は、現実の多くのHDDが512バイト＝1セクタに対する書き込みに関してatomicになっているからである。実際には古い*EoR*を、新しいメモリバッファの先頭でatomicに上書きさえできれば良い。*EoR*の消去（上書き）がatomicに行われずに強制終了した場合は、ジャーナル領域として壊れてしまう。この最後の書き込みがatomicに行われるために、メモリバッファ全体の書き出しがatomicになるとも言える。

### コードではどうなっているか
`flush_write_buf`メソッドが、上記のアルゴリズムに沿うように変更された
https://github.com/frugalos/cannyls/pull/29/files#diff-5664d011af898065aad8d33346649d30R115

Cannylsを新しい挙動で使いたい場合には、以下のようにする
```
    let filenvm = FileNvm::create(filepath, capacity).unwrap();
    let mut builder = StorageBuilder::new();
    builder.journal_safe_flush(true); // <-
    builder.create(filenvm).unwrap()
```

## 状況2について
状況1と同じように、新しい方の*EoR*を書き出してから、既存の*EoR*を`GoToFront`で上書きする。

1. `GoToFront`を書く前に、一度先頭にシークする
2. レコードと*EoR*を書く
3. 永続化する
4. `GoToFront`を書くべき位置までシークによって戻り、書き出す。

### コードでの対応
上に述べた挙動でジャーナルレコードを追加する`safe_enqueue`メソッドを導入した:
https://github.com/frugalos/cannyls/pull/29/files#diff-42653effaf88e3f0b6c1217764dc36aeR182

Cannylsを新しい挙動で使いたい場合には、以下のようにする
```
    let filenvm = FileNvm::create(filepath, capacity).unwrap();
    let mut builder = StorageBuilder::new();
    builder.journal_safe_enqueue(true); // <-
    builder.create(filenvm).unwrap()
```


# このPRの有効性の確認
[issue27の検証用リポジトリ](https://github.com/yuezato/cannyls_eor_vanish)にこのPRを取り込んだブランチ https://github.com/yuezato/cannyls_eor_vanish/tree/use_PR_for_issue27 を用いると、これまで発生していた`StorageCorrupted`エラーが生じなくなる。

# パフォーマンス低下について
## 状況1について
状況1では、これまでジャーナルバッファのflush時には`sync`を行っていなかったのに対して、この修正では1発の`sync`が必要になるため、バッファflush時には50ms前後（一般的なHDDに対するfsyncはこの程度の時間を要する）のレイテンシ悪化が発生する。

ジャーナルバッファのflushをユーザ層で意図的に大量に発生させるためには、埋め込みPUTしたバッファ上にあるデータに対するGETを行う場合に限られる。
Frugalosではfrugalos_raftの票管理やlog_prefix, log_suffixで埋め込みPUTを行うため、パフォーマンスが劣化する可能性がある。

## 状況2について
状況2でも新たに`sync`を行うため同様にレイテンシが悪化するが、ring状のジャーナル領域の末尾を指すtail pointerが一周する時にのみ発生するため、ほとんどの場合は問題がない。