### PR TITLE
issue28のパッチ

### DIFF
--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -487,7 +487,7 @@ mod tests {
         let mut parent = dir.as_ref();
         while let Some(p) = parent.parent() {
             parent = p;
-        };
+        }
         assert!(create_parent_directories(parent).is_ok());
         Ok(())
     }

--- a/src/storage/allocator/data_portion_allocator.rs
+++ b/src/storage/allocator/data_portion_allocator.rs
@@ -195,7 +195,7 @@ impl DataPortionAllocator {
     //    現在の実装では `nth(0)` を用いているため、
     //    フリーリスト内の相異なる部分領域が互いに素であるという前提が必要である。
     //    ただしこの前提は通常のCannyLSの使用であれば成立する。
-    fn is_allocated_portion(&self, portion: &DataPortion) -> bool {
+    pub(crate) fn is_allocated_portion(&self, portion: &DataPortion) -> bool {
         let key = EndBasedFreePortion(FreePortion::new(portion.start, 0));
         if let Some(next) = self.end_to_free.range((Excluded(&key), Unbounded)).nth(0) {
             // 終端位置が `portion.start` を超えるfree portionのうち最小のもの `next` については

--- a/src/storage/data_region.rs
+++ b/src/storage/data_region.rs
@@ -24,6 +24,11 @@ impl<N> DataRegion<N>
 where
     N: NonVolatileMemory,
 {
+    #[allow(dead_code)]
+    pub(crate) fn allocator(&self) -> &DataPortionAllocator {
+        &self.allocator
+    }
+
     /// 新しい`DataRegion`インスタンスを生成する.
     pub fn new(metric_builder: &MetricBuilder, allocator: DataPortionAllocator, nvm: N) -> Self {
         let capacity = allocator.metrics().capacity_bytes;

--- a/src/storage/data_region.rs
+++ b/src/storage/data_region.rs
@@ -24,11 +24,6 @@ impl<N> DataRegion<N>
 where
     N: NonVolatileMemory,
 {
-    #[allow(dead_code)]
-    pub(crate) fn allocator(&self) -> &DataPortionAllocator {
-        &self.allocator
-    }
-
     /// 新しい`DataRegion`インスタンスを生成する.
     pub fn new(metric_builder: &MetricBuilder, allocator: DataPortionAllocator, nvm: N) -> Self {
         let capacity = allocator.metrics().capacity_bytes;
@@ -107,6 +102,11 @@ where
     /// `size`分のデータをカバーするのに必要なブロック数.
     fn block_count(&self, size: u32) -> u32 {
         (size + u32::from(self.block_size.as_u16()) - 1) / u32::from(self.block_size.as_u16())
+    }
+
+    // The following methods are for unit tests.
+    pub(crate) fn allocator(&self) -> &DataPortionAllocator {
+        &self.allocator
     }
 }
 

--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -38,7 +38,7 @@ impl LumpIndex {
     ///
     /// 結果は昇順にソートされている.
     pub fn remove(&mut self, lump_id: &LumpId) -> Option<Portion> {
-        self.map.remove(lump_id).map(|p| p.into())
+        self.map.remove(lump_id).map(std::convert::Into::into)
     }
 
     /// 登録されているlumpのID一覧を返す.

--- a/src/storage/journal/delayed_release_info.rs
+++ b/src/storage/journal/delayed_release_info.rs
@@ -1,0 +1,220 @@
+use std::convert::Into;
+use std::vec::Vec;
+use storage::portion::{DataPortion, DataPortionU64};
+
+/// 削除操作によって消されたDataPortionを表すためのVec<DataPortion64>に対するnew type。
+#[derive(Debug, Clone)]
+struct DataPortion64s(Vec<DataPortionU64>);
+
+impl DataPortion64s {
+    /// 対応するDataPortionのリストを復元する関数。
+    pub fn to_data_portions(&self) -> Vec<DataPortion> {
+        self.0.iter().cloned().map(Into::into).collect()
+    }
+}
+
+/// 遅延解放のために必要になる情報と操作を集約する構造体。
+#[derive(Debug)]
+pub struct DelayedReleaseInfo {
+    // ジャーナル領域をopenした以降に追加したDelete及びDeleteRangeレコードで、永続化が確定済みのものの数
+    num_of_releasable_delete_records: usize,
+    // ジャーナル領域のrestore時に処理済みのDelete及びDeleteRangeレコードで、未だGCキューに投入されていないものの数
+    num_of_unqueued_initial_delete_records: usize,
+    // 永続化済みのDelete及びDeleteRangeレコードに紐づく、解放可能なPortionを表現するための集合
+    entries: Vec<DataPortion64s>,
+}
+impl DelayedReleaseInfo {
+    pub fn new() -> Self {
+        DelayedReleaseInfo {
+            num_of_releasable_delete_records: 0,
+            num_of_unqueued_initial_delete_records: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(in storage::journal) fn num_of_releasable_delete_records(&self) -> usize {
+        self.num_of_releasable_delete_records
+    }
+
+    #[allow(dead_code)]
+    pub(in storage::journal) fn num_of_unqueued_initial_delete_records(&self) -> usize {
+        self.num_of_unqueued_initial_delete_records
+    }
+
+    pub fn releasable_data_portions(&self) -> Vec<DataPortion> {
+        let n = self.num_of_releasable_delete_records;
+        (&self.entries)[..n]
+            .iter()
+            .flat_map(DataPortion64s::to_data_portions)
+            .collect()
+    }
+
+    pub fn take_releasable_data_portions(&mut self) -> Vec<DataPortion> {
+        let n = self.num_of_releasable_delete_records;
+        self.num_of_releasable_delete_records = 0;
+        self.entries
+            .drain(..n)
+            .flat_map(|e| DataPortion64s::to_data_portions(&e))
+            .collect()
+    }
+
+    pub fn set_initial_delete_records(&mut self, u: usize) {
+        self.num_of_unqueued_initial_delete_records = u;
+    }
+
+    pub fn detect_new_synced_delete_records(&mut self, u: usize) {
+        if self.num_of_unqueued_initial_delete_records == 0 {
+            self.num_of_releasable_delete_records += u;
+        } else if self.num_of_unqueued_initial_delete_records >= u {
+            self.num_of_unqueued_initial_delete_records -= u;
+        } else {
+            self.num_of_releasable_delete_records +=
+                u - self.num_of_unqueued_initial_delete_records;
+            self.num_of_unqueued_initial_delete_records = 0;
+        }
+    }
+
+    pub fn insert_data_portions(&mut self, portions: Vec<DataPortion>) {
+        self.entries.push(DataPortion64s(
+            portions.into_iter().map(Into::into).collect(),
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use self::DataPortion64s;
+    use super::*;
+    use trackable::result::TestResult;
+
+    fn make_dataportion(start: u16, len: u16) -> DataPortion {
+        use storage::Address;
+        DataPortion {
+            start: Address::from_u64(u64::from(start)).unwrap(),
+            len,
+        }
+    }
+
+    fn make_dataportion64(start: u16, len: u16) -> DataPortionU64 {
+        make_dataportion(start, len).into()
+    }
+
+    #[test]
+    fn to_data_portions_works() -> TestResult {
+        let portion = make_dataportion64(0, 0);
+        let single_delete = DataPortion64s(vec![portion.clone()]);
+        assert_eq!(single_delete.to_data_portions(), vec![portion.into()]);
+
+        let portion_range: Vec<DataPortionU64> =
+            (0..10).map(|i| make_dataportion64(i, i)).collect();
+        let deletes = DataPortion64s(portion_range);
+        assert_eq!(
+            deletes.to_data_portions(),
+            (0..10)
+                .map(|i| make_dataportion(i, i))
+                .collect::<Vec<DataPortion>>()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn num_of_releasable_delete_records_reflects_correct_number() -> TestResult {
+        let mut info = DelayedReleaseInfo::new();
+
+        // Journal領域のopen中に、併せて5つのDeleteまたはDeleteRangeレコードとする。
+        info.set_initial_delete_records(5);
+
+        // fill_gc_queue中に、3つのDeleteまたはDeleteRangeレコードを見つけたとする。
+        info.detect_new_synced_delete_records(3);
+
+        // open時にみつけたDeleteまたはDeleteRangeレコードのうち
+        // まだ2つはGCキューに入っていない。
+        assert_eq!(info.num_of_unqueued_initial_delete_records(), 2);
+        // 解放して意味のあるDeleteまたはDeleteRangeレコードは存在しない。
+        assert_eq!(info.num_of_releasable_delete_records(), 0);
+
+        // fill_gc_queue中に、新たに4つのDeleteまたはDeleteRangeレコードを見つけたとする。
+        info.detect_new_synced_delete_records(4);
+
+        // open時に見つけたDeleteまたはDeleteRangeレコードは全てGCキューに入った
+        assert_eq!(info.num_of_unqueued_initial_delete_records(), 0);
+        // open以降に作成されたDeleteまたはDeleteRangeレコードで、解放して問題ないものは2つある。
+        assert_eq!(info.num_of_releasable_delete_records(), 2);
+
+        info.detect_new_synced_delete_records(1);
+        assert_eq!(info.num_of_unqueued_initial_delete_records(), 0);
+        assert_eq!(info.num_of_releasable_delete_records(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn releasable_data_portions_works() -> TestResult {
+        let mut info = DelayedReleaseInfo::new();
+
+        info.set_initial_delete_records(2);
+
+        info.insert_data_portions(vec![make_dataportion(0, 0)]);
+        info.insert_data_portions(vec![make_dataportion(1, 1)]);
+        info.insert_data_portions(vec![make_dataportion(2, 2)]);
+
+        info.detect_new_synced_delete_records(1);
+        assert_eq!(info.releasable_data_portions(), vec![]);
+
+        info.detect_new_synced_delete_records(2);
+        assert_eq!(
+            info.releasable_data_portions(),
+            vec![make_dataportion(0, 0)]
+        );
+
+        let portions: Vec<DataPortion> = (20..30).map(|i| make_dataportion(i, i)).collect();
+
+        info.insert_data_portions(portions.clone());
+        info.detect_new_synced_delete_records(3);
+
+        let mut tmp = vec![
+            make_dataportion(0, 0),
+            make_dataportion(1, 1),
+            make_dataportion(2, 2),
+        ];
+        tmp.extend(portions.clone());
+        assert_eq!(info.releasable_data_portions(), tmp);
+
+        Ok(())
+    }
+
+    #[test]
+    fn take_releasable_data_portions_works() -> TestResult {
+        let mut info = DelayedReleaseInfo::new();
+
+        info.set_initial_delete_records(2);
+
+        info.insert_data_portions(vec![make_dataportion(0, 0)]);
+        info.insert_data_portions(vec![make_dataportion(1, 1)]);
+        info.insert_data_portions(vec![make_dataportion(2, 2)]);
+
+        info.detect_new_synced_delete_records(1);
+        assert_eq!(info.releasable_data_portions(), vec![]);
+
+        info.detect_new_synced_delete_records(2);
+        assert_eq!(
+            info.take_releasable_data_portions(),
+            vec![make_dataportion(0, 0)]
+        );
+        assert_eq!(info.releasable_data_portions(), vec![]);
+
+        let portions: Vec<DataPortion> = (20..30).map(|i| make_dataportion(i, i)).collect();
+
+        info.insert_data_portions(portions.clone());
+        info.detect_new_synced_delete_records(3);
+
+        let mut tmp = vec![make_dataportion(1, 1), make_dataportion(2, 2)];
+        tmp.extend(portions.clone());
+        assert_eq!(info.take_releasable_data_portions(), tmp);
+        assert_eq!(info.releasable_data_portions(), vec![]);
+
+        Ok(())
+    }
+}

--- a/src/storage/journal/mod.rs
+++ b/src/storage/journal/mod.rs
@@ -1,9 +1,11 @@
+pub use self::delayed_release_info::DelayedReleaseInfo;
 pub use self::header::{JournalHeader, JournalHeaderRegion};
 pub use self::nvm_buffer::JournalNvmBuffer;
 pub use self::options::JournalRegionOptions;
 pub use self::record::{JournalEntry, JournalRecord};
 pub use self::region::JournalRegion;
 
+pub mod delayed_release_info;
 mod header;
 mod nvm_buffer;
 mod options;

--- a/src/storage/journal/mod.rs
+++ b/src/storage/journal/mod.rs
@@ -5,7 +5,7 @@ pub use self::options::JournalRegionOptions;
 pub use self::record::{JournalEntry, JournalRecord};
 pub use self::region::JournalRegion;
 
-pub mod delayed_release_info;
+mod delayed_release_info;
 mod header;
 mod nvm_buffer;
 mod options;

--- a/src/storage/portion.rs
+++ b/src/storage/portion.rs
@@ -79,6 +79,22 @@ impl From<PortionU64> for Portion {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataPortionU64(u64);
+impl From<DataPortion> for DataPortionU64 {
+    fn from(f: DataPortion) -> Self {
+        let (offset, len) = (f.start.as_u64(), u64::from(f.len));
+        DataPortionU64(offset | (len << 40))
+    }
+}
+impl From<DataPortionU64> for DataPortion {
+    fn from(f: DataPortionU64) -> Self {
+        let len = (f.0 >> 40) as u16;
+        let start = Address::from_u64(f.0 & Address::MAX).unwrap();
+        DataPortion { start, len }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::mem;

--- a/src/storage/portion.rs
+++ b/src/storage/portion.rs
@@ -79,6 +79,7 @@ impl From<PortionU64> for Portion {
     }
 }
 
+/// `Portion`に対する`PortionU64`同様に、`DataPortion`の内部表現のサイズを64bitにした構造体.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataPortionU64(u64);
 impl From<DataPortion> for DataPortionU64 {


### PR DESCRIPTION
# PRの状態
- [x] アルゴリズムの実装
- [x] コードレベルコメント（ドキュメントコメントも含め）の追加
- [x] ここでのアルゴリズムの説明
- [x] ここでのアルゴリズムの正当性の説明
- [x] テストの追加
- [x] ジャーナル領域センシティブな既存テストコードの修正と既存テストコードの修正が必要な理由
- [x] 議論しておくべき点の洗い出し
- [ ] 実行時間に関する計測結果
- [ ] リソース使用量に関する計測結果

# このPRの狙い
Cannylsのissue https://github.com/frugalos/cannyls/issues/28 を解決する。

# アルゴリズム

## アイディア

リソースの解放要求を、現時点の実装（Storageでdeleteを行ったタイミングでアロケータに解放要求を送る）より遅らせる。

より正確には、Storageでdeleteを行いdata portion pをlump indexから取り外した際に、アロケータにpの解放要求を送らず、それを貯めておき、対応するDeleteレコードがストレージに永続化されたことが確認できたタイミングでアロケータにpの解放要求を送る。同様のことをdelete_rangeに対しても行う。

## 制約

- 可能な限りメモリ使用量を抑える
- ストレージフォーマットは極力変更しない

制約を考えない場合の最も素朴な実装は

1. storage::deleteまたはstorage::delete_range実行時にジャーナル領域に書き出すDelete及びDeleteRangeレコードに単調増加するidを付与する;
2. そのidとdata portionをHashMapなどで紐付けてメモリ上に保持する;
3. 永続化が確定したDelete及びDeleteRangeを見つける度に、そのidから削除対象のdata portionを辿りアロケータに解放要求を送る;

といったものが考えられる。ただしこの方法ではストレージフォーマットを変更しなくてはならず、一時記憶が避けられないdata portionに加えてid達も追加で覚えなくてはならず、最適とは言い難い。

## 実装

- Storage層でdelete、delete_range及び上書きputをした際にlump indexから外れたdata portionを記憶する。
  - `DelayedReleaseInfo`構造体の`insert_data_portions`メソッドを用いる。
- Delete及びDeleteRangeレコードがストレージ上に永続化されたかどうかを、GCキューにエンキューするタイミングを用いて確認する。
  - 新たに永続化が確定したレコードの個数だけを`DelayedReleaseInfo::detect_new_synced_delete_records`で記録する。
- `insert_data_portions`でバッファしているdata portion達について、`detect_new_synced_delete_records`される度に先頭からその分だけ解放可能な領域としてアロケータに解放要求を送る。

## 正当性

このPRの実装では、Deleteレコード及びDeleteRangeレコードに個別にidを割り振っていない。

ジャーナル領域がring bufferすなわちFIFO構造をなすので、先にジャーナル領域に追加されたDeleteレコードまたはDeleteRangeレコードでは、先にデキューされたGCキューに登録されるからである。

これは`DelayedReleaseInfo`構造体にバッファする場合でも同様であるから、幾つのレコードが新たに安全に解放可能になったかという個数の情報だけが必要になる。

## 挙動の図式的な説明

最後に簡単な例を用いて実際の挙動を説明する。以下では簡単のために削除レコードだけを記載する。

```
ジャーナル領域の初期状態 [DEL(0)][DEL_RANGE(10, 20)][DEL(100)] 
```

起動時に判明する情報として、まだGCキューに入っていない永続化済み削除レコードの数として「３」を記憶する。適当な操作のあと、以下の状態に遷移したとする:

```
region: [DEL(0)][DEL_RANGE(10, 20)][DEL(100)][DEL(42)][DEL_RANGE(1000, 1010)][DEL(43)]
```

二つの削除操作がジャーナル領域open後に行われ、次の順番で削除候補data portionをバッファしているとする:

```
buffer: [<0x1234>][<0x4310, 0x4311, 0x4312, ..., 0x431a>][<0x1235>]
```

さて、GCキューへの追加により`DEL(42)`までがエンキューされたとする:

```
queue: [DEL(0)][DEL_RANGE(10, 20)][DEL(100)][DEL(42)]
region: [DEL(43)][DEL_RANGE(1000, 1010)]
```

エンキューの過程で永続化が確定している削除レコード4つに遭遇したことになる。このうち3つのレコードは初期状態から存在していたものであるから、実際には4-3=1個のレコードがlump indexからdata portionを除外した本質的な削除操作ということになる。従って、バッファの先頭に存在する`0x1234` が安全に解放できるということになる。

更に処理が進み

```
queue: [DEL(0)][DEL_RANGE(10, 20)][DEL(100)][DEL(42)][DEL_RANGE(1000, 1010)]
region: [DEL(43)]
```

の状態では5-3=2個のレコードが永続化された本質的な削除操作であることが分かり、新たに`<0x4310, 0x4311, 0x4312, ..., 0x431a>`の10個が一挙に安全に解放可能になることを意味する。

最後に

```
queue: [DEL(0)][DEL_RANGE(10, 20)][DEL(100)][DEL(42)][DEL_RANGE(1000, 1010)][DEL(43)]
region: ∅
```

となり、6-3=3個のレコードが永続化された本質的な削除操作であることが分かり、`0x1235`が新たに安全に解放可能になることを意味する。

# このPRで発生する問題
* 使用可能なデータ領域が減ってみえる
    * （現実装と比べると）GCキューにエンキューされるまで解放されず、GCキューは空になるまでエンキューされない実装となっているので、キューの長さによっては長い期間、アロケータから見える利用可能領域が現象する。
* 使用するジャーナル領域が増える
    * 上書きPUT時にDELETEレコードを書き込むようになったため。
    * https://github.com/frugalos/cannyls/pull/31/files#diff-a2828e4f71806f3e4623d048057803d4R198
* メモリ使用量が増える
   * 解放要求を遅延するため、解放対象となるDataPortionを覚えるためのメモリ空間を最低限必要とする（DataPortionだけでは正しい実装が不可能な場合には、更に追加でメモリ空間が必要となる）。

# 既存のテストコードの修正について
## `storage::mod::tests::full`に対する修正の理由
https://github.com/frugalos/cannyls/pull/31/files#diff-a2828e4f71806f3e4623d048057803d4R672
* このテストは暗黙にアロケータの挙動に依存していた。同じデータサイズで上書きPUTすると即座に再利用されるため、たまたまテストに成功していた。
* 遅延解放を採用したので、明示的に解放処理を追加する必要が新たに生じた。

## `storage::mode::tests::confirm_that_the_problem_of_pr23_is_resolved`に対する修正の理由
https://github.com/frugalos/cannyls/pull/31/files#diff-a2828e4f71806f3e4623d048057803d4R1005
* 遅延解放の実装のために、上書きPUT時にはDELETEレコードをジャーナル領域に明示的に書き出す変更を行った。これに伴い、 ジャーナル領域上の位置を表す各種ポインタの取る値が変動したためである。

# 議論しておくべき点
## 実際の解放処理をどこで行うか
現在は `run_side_job_once` が呼ばれる度に、その段階で安全に解放可能なデータポーションを全てアロケータに通知して解放するようにしている。
https://github.com/frugalos/cannyls/pull/31/files#diff-a2828e4f71806f3e4623d048057803d4R316

* 解放のスパンが長くなりすぎていないか？
* 一回に全てを解放して良いか（解放処理はフリーリストのマージなどを行うため、大量に行ってしまうと無視できない時間スレッドをブロックする可能性がある）

## リソース使用量に関する議論
GCが行われるまで`DelayedReleaseInfo`に`DataPortionU64`を格納し続けることになるため、大量のメモリが必要になる。これは以下の簡単な計算で確認できる:
1. 8TBのHDDをデフォルトの設定で用いるとする。このとき、1%がジャーナル空間に割り当たるため、80GBがジャーナル空間となる。
2. GCはストレージ層ではジャーナル空間の半分を超えてはじめて開始される。
https://github.com/frugalos/cannyls/blob/87599402837317bb03efd842db2c07b97488edce/src/storage/journal/region.rs#L172-L176
3. 従って、40GB以上ジャーナル空間が使われるまではメモリに解放することのできない`DataPortionU64`が格納されることになる。例えば PUTの直後にDELETE を繰り返す場合は、40GBのジャーナル空間にPUTとDELETEをそれぞれ3.5億(1件30バイトで計算)エントリ追加できる。
4. すなわち、メモリには `8バイト*3.5億=2.8GB`の空間が必要になる。

以上の計算はデバイス層を無視してストレージ層を直接使った場合の話で、デバイス層では一定時間コマンドが発行されずにアイドリングが続いた時（[デフォルトでは100ms](https://github.com/frugalos/cannyls/blob/87599402837317bb03efd842db2c07b97488edce/src/device/builder.rs#L24)）に[GCが呼び出される](https://github.com/frugalos/cannyls/blob/87599402837317bb03efd842db2c07b97488edce/src/device/thread.rs#L104) ため、一般的な使用状況では緩和されることになる。
ただし、100ms以内に常にデータが飛んでくる場合には、結局の所ストレージ層単体の計算となり、大量のメモリが必要になることに変わりはない。

なお一回のGCでは[デフォルトで4096](https://github.com/frugalos/cannyls/blob/87599402837317bb03efd842db2c07b97488edce/src/storage/journal/options.rs#L15)エンキューされる、すなわち最大で4096エントリ解放可能になるだけであり、3.5億エントリある状況では焼け石に水である。

### 対策
`DelayedReleaseInfo`にサイズ上限を設けたほうが良いだろう。
このサイズ上限にリーチした場合にはGCを行わなくてはならないとする。
ただし、GCを行ったとしても解放できるとは限らないことから、あまり抜本的な対策にはなっていない。

# パフォーマンス測定
## 実行時間に関する測定
アロケータの挙動が変わってしまうため、フェアな測定が難しい。

## メモリ使用量について
`valgrind --tool=massif`を用いて測定できる。