### PR TITLE
Resolve the warning by new Clippy 0.0.212 (1fac3808 2019-02-20)

### DIFF
--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -38,7 +38,7 @@ impl LumpIndex {
     ///
     /// 結果は昇順にソートされている.
     pub fn remove(&mut self, lump_id: &LumpId) -> Option<Portion> {
-        self.map.remove(lump_id).map(|p| p.into())
+        self.map.remove(lump_id).map(std::convert::Into::into)
     }
 
     /// 登録されているlumpのID一覧を返す.


### PR DESCRIPTION
# Motivation & Goal
[After migrating to Rust 1.34.0](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html), the cargo-clippy newly warns the following:
```
warning: redundant closure found
  --> src/storage/index.rs:41:38
   |
41 |         self.map.remove(lump_id).map(|p| p.into())
   |                                      ^^^^^^^^^^^^ help: remove closure as shown: `std::convert::Into::into`
   |
   = note: #[warn(clippy::redundant_closure)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```
(You can also see this warning at [this TravisCI log](https://travis-ci.org/frugalos/cannyls/jobs/519717328#L667).)

This PR suppresses the above warning without changing the semantics of the codes.

# Changes
Before
```rust
pub fn remove(&mut self, lump_id: &LumpId) -> Option<Portion> {
    self.map.remove(lump_id).map(|p| p.into())
                                 ^^^^^^^^^^^^
}
```
After
```rust
pub fn remove(&mut self, lump_id: &LumpId) -> Option<Portion> {
    self.map.remove(lump_id).map(std::convert::Into::into)
}
```