### PR TITLE
nvm_bufferのdirty areaの読み込み時にsyncするように変更

### DIFF
--- a/src/storage/journal/nvm_buffer.rs
+++ b/src/storage/journal/nvm_buffer.rs
@@ -180,7 +180,7 @@ impl<N: NonVolatileMemory> Seek for JournalNvmBuffer<N> {
 impl<N: NonVolatileMemory> Read for JournalNvmBuffer<N> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.is_dirty_area(self.position, buf.len()) {
-            track!(self.flush_write_buf())?;
+            track!(self.sync())?;
         }
 
         let aligned_start = self.block_size().floor_align(self.position);


### PR DESCRIPTION
# 現状の問題点
ジャーナルバッファ（の特に書き込みバッファ）については次のような文面がある:
https://github.com/frugalos/cannyls/blob/c789ba326d5c2bef973481c1f0b528d4544472af/src/storage/journal/nvm_buffer.rs#L21-L36

このうちで特に、バッファしている領域をreadしようとした際には、その領域を永続化（フラッシュして同期までする）した上で、（高速化のために）バッファから値を読むことをしている。

一方で、現在の実装ではフラッシュはするが同期までは行っていない:
https://github.com/frugalos/cannyls/blob/c789ba326d5c2bef973481c1f0b528d4544472af/src/storage/journal/nvm_buffer.rs#L181-L184

# このPRでやること
文言の通りにsyncを行う。