### PR TITLE
Clippy 0.0.212 (726176e3 2019-04-18) に対応

### DIFF
--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -38,7 +38,7 @@ impl LumpIndex {
     ///
     /// 結果は昇順にソートされている.
     pub fn remove(&mut self, lump_id: &LumpId) -> Option<Portion> {
-        self.map.remove(lump_id).map(|p| p.into())
+        self.map.remove(lump_id).map(std::convert::Into::into)
     }
 
     /// 登録されているlumpのID一覧を返す.


### PR DESCRIPTION
# このPRで行っていること
新しいClippyで以下のwarningが出ており、Travisのbuildに失敗するので対応します:
```
$ cargo clippy --version
clippy 0.0.212 (726176e3 2019-04-18)

$ cargo clippy
warning: redundant closure found
  --> src/storage/index.rs:41:38
   |
41 |         self.map.remove(lump_id).map(|p| p.into())
   |                                      ^^^^^^^^^^^^ help: remove closure as shown: `std::convert::Into::into`
   |
   = note: #[warn(clippy::redundant_closure)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```