### PR TITLE
Rust 1.35.0付属のrustfmt 1.2.0-stableとclippy 0.0.212に対応

### DIFF
--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -487,7 +487,7 @@ mod tests {
         let mut parent = dir.as_ref();
         while let Some(p) = parent.parent() {
             parent = p;
-        };
+        }
         assert!(create_parent_directories(parent).is_ok());
         Ok(())
     }

--- a/src/storage/journal/region.rs
+++ b/src/storage/journal/region.rs
@@ -329,6 +329,7 @@ where
     }
 
     /// リングバッファおよびインデックスを前回の状態に復元する.
+    #[allow(clippy::identity_conversion)]
     fn restore(&mut self, index: &mut LumpIndex) -> Result<()> {
         for result in track!(self.ring_buffer.restore_entries())? {
             let JournalEntry { start, record } = track!(result)?;

--- a/src/storage/journal/region.rs
+++ b/src/storage/journal/region.rs
@@ -329,8 +329,14 @@ where
     }
 
     /// リングバッファおよびインデックスを前回の状態に復元する.
-    #[allow(clippy::identity_conversion)]
     fn restore(&mut self, index: &mut LumpIndex) -> Result<()> {
+        /*
+         * 次のattributeはclippy 0.0.212(265318db 2019-05-17)で生じる
+         * false positiveな警告を抑えるためのもの。
+         * (see: https://github.com/rust-lang/rust-clippy/issues/4133)
+         * Stableのclippy versionが上がったタイミングで外す。
+         */
+        #![allow(clippy::identity_conversion)]
         for result in track!(self.ring_buffer.restore_entries())? {
             let JournalEntry { start, record } = track!(result)?;
             match record {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -248,9 +248,9 @@ where
         // ジャーナル領域に範囲削除レコードを一つ書き込むため、一度のディスクアクセスが起こる。
         // 削除レコードを範囲分書き込むわけ *ではない* ため、複数回のディスクアクセスは発生しない。
         track!(self
-               .journal_region
-               .records_delete_range(&mut self.lump_index, range))?;
-        
+            .journal_region
+            .records_delete_range(&mut self.lump_index, range))?;
+
         for lump_id in &targets {
             if let Some(portion) = self.lump_index.remove(lump_id) {
                 self.metrics.delete_lumps.increment();
@@ -262,7 +262,7 @@ where
                     self.data_region.delete(portion);
                 }
             }
-        }        
+        }
 
         Ok(targets)
     }


### PR DESCRIPTION
# このPRの狙い
Rust 1.35.0にバージョンが上がり、clippyのバージョンが以下のようになりました
```
$ cargo clippy --version
clippy 0.0.212 (265318db 2019-05-17)
```
これに伴い以下のようなwarningが生じています:
```
warning: identical conversion
   --> src/storage/journal/region.rs:333:23
    |
333 |         for result in track!(self.ring_buffer.restore_entries())? {
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `track!(self.ring_buffer.restore_entries())?()`: `track!(self.ring_buffer.restore_entries())?`
    |
    = note: #[warn(clippy::identity_conversion)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
warning: identical conversion
   --> src/storage/journal/region.rs:333:23
    |
333 |         for result in track!(self.ring_buffer.restore_entries())? {
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `track!(self.ring_buffer.restore_entries())?()`: `track!(self.ring_buffer.restore_entries())?`
    |
    = note: #[warn(clippy::identity_conversion)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
```

これを解決します。

## 内容
解決するといっても`track!`を取り除くことはできないので、`clippy::identity_conversion`をallowしました。

## 追加の変更点
Rust fmtがしばらく実行されていなかったようなので、これも併せて実行します。
```
rustfmt 1.2.0-stable (09940a70 2019-03-27)
```