### PR TITLE
Bump version to 0.9.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cannyls"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["The FrugalOS Developers"]
 description = "Embedded persistent key-value storage optimized for random-access workload and huge-capacity HDD"
 homepage = "https://github.com/frugalos/cannyls"


### PR DESCRIPTION
This version includes following changes: https://github.com/frugalos/cannyls/compare/8759940...d5420b0

- Fix clippy warnings #32 #36 #37 #41
- Add logger to DeviceThread #38
- Add disk-usage feature #42