### PR TITLE
Fix clippy's warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 
 script:
   - cargo test
-  - cargo clippy
+  - cargo clippy --lib --tests
 
 matrix:
   allow_failures:

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -443,9 +443,9 @@ mod tests {
         assert_eq!(512u16, header.block_size.as_u16());
         assert_eq!(0, usage.bytecount().unwrap());
         // 1 block(included)
-        track!(execute(d.request().put(id(0), data(&vec![0; 510]))))?;
+        track!(execute(d.request().put(id(0), data(&[0; 510]))))?;
         // 2 blocks(included)
-        track!(execute(d.request().put(id(1), data(&vec![0; 511]))))?;
+        track!(execute(d.request().put(id(1), data(&[0; 511]))))?;
         // 1 block(excluded)
         track!(execute(d.request().put(id(12), data(b"baz"))))?;
         let usage = track!(execute(d.request().usage_range(Range {
@@ -458,7 +458,7 @@ mod tests {
             end: id(1)
         })))?;
         assert_eq!(
-            header.block_size.as_u16() * 1,
+            header.block_size.as_u16(),
             usage.bytecount().unwrap() as u16
         );
         let usage = track!(execute(d.request().usage_range(Range {

--- a/src/nvm/file.rs
+++ b/src/nvm/file.rs
@@ -561,7 +561,7 @@ mod tests {
         let dir = track_io!(TempDir::new("cannyls_test"))?;
         let capacity = 10 * 1024;
         let filepath = dir.path().join("foo").join("bar").join("buzz");
-        let parent = track_io!(filepath.parent().ok_or(io::Error::new(
+        let parent = track_io!(filepath.parent().ok_or_else(|| io::Error::new(
             io::ErrorKind::NotFound,
             "Parent directory must be present"
         )))?;

--- a/src/storage/allocator/data_portion_allocator.rs
+++ b/src/storage/allocator/data_portion_allocator.rs
@@ -105,8 +105,8 @@ impl DataPortionAllocator {
             .size_to_free
             // `SizedBasedFreePortion`の全順序を用いて `size` を含むFreePortionを探す
             .range((Included(&portion), Unbounded))
-            // 従って、nth(0)では（存在すれば）size以上かつ最小のFreePortionを取得することになる
-            .nth(0)
+            // 従って、next()では（存在すれば）size以上かつ最小のFreePortionを取得することになる
+            .next()
             .map(|p| p.0)
         {
             debug_assert!(U24::from(size) <= free.len());
@@ -174,7 +174,7 @@ impl DataPortionAllocator {
         if let Some(next) = self
             .end_to_free
             .range((Excluded(&EndBasedFreePortion(key)), Unbounded))
-            .nth(0)
+            .next()
             .map(|p| p.0)
         {
             // `next`については`portion.end < next.end`を満たす最小のポーションということしか分かっていない。
@@ -192,12 +192,12 @@ impl DataPortionAllocator {
     // 領域が重なっていない場合 <=> 返り値がtrue に限り、割当済みの領域であると判断する。
     //
     // メモ:
-    //    現在の実装では `nth(0)` を用いているため、
+    //    現在の実装では `next()` を用いているため、
     //    フリーリスト内の相異なる部分領域が互いに素であるという前提が必要である。
     //    ただしこの前提は通常のCannyLSの使用であれば成立する。
     fn is_allocated_portion(&self, portion: &DataPortion) -> bool {
         let key = EndBasedFreePortion(FreePortion::new(portion.start, 0));
-        if let Some(next) = self.end_to_free.range((Excluded(&key), Unbounded)).nth(0) {
+        if let Some(next) = self.end_to_free.range((Excluded(&key), Unbounded)).next() {
             // 終端位置が `portion.start` を超えるfree portionのうち最小のもの `next` については
             // - portion.end() <= next.0.start() すなわち overlapしていないか
             // - portion.end() > next.0.start() すなわち overlapしているか

--- a/src/storage/data_region.rs
+++ b/src/storage/data_region.rs
@@ -186,13 +186,13 @@ mod tests {
 
         // put
         let mut data = DataRegionLumpData::new(3, block_size);
-        data.as_bytes_mut().copy_from_slice("foo".as_bytes());
+        data.as_bytes_mut().copy_from_slice(b"foo");
         let portion = track!(region.put(&data))?;
 
         // get
         assert_eq!(
             region.get(portion).ok().map(|d| d.as_bytes().to_owned()),
-            Some("foo".as_bytes().to_owned())
+            Some(b"foo".to_vec())
         );
         Ok(())
     }

--- a/src/storage/journal/ring_buffer.rs
+++ b/src/storage/journal/ring_buffer.rs
@@ -466,14 +466,14 @@ mod tests {
         let nvm = MemoryNvm::new(vec![0; 1024]);
         let mut ring = JournalRingBuffer::new(nvm, 0, &MetricBuilder::new());
 
-        let record = record_embed("000", &vec![0; 997]);
+        let record = record_embed("000", &[0; 997]);
         assert_eq!(record.external_size(), 1020);
         assert_eq!(
             ring.enqueue(&record).err().map(|e| *e.kind()),
             Some(ErrorKind::StorageFull)
         );
 
-        let record = record_embed("000", &vec![0; 996]);
+        let record = record_embed("000", &[0; 996]);
         assert_eq!(record.external_size(), 1019);
         assert!(ring.enqueue(&record).is_ok());
         assert_eq!(ring.tail, 1019);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -368,8 +368,7 @@ where
                 self.data_region.delete(portion);
                 e
             }))?;
-        self.lump_index
-            .insert(lump_id.clone(), Portion::Data(portion));
+        self.lump_index.insert(*lump_id, Portion::Data(portion));
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -653,7 +653,7 @@ mod tests {
 
         // [NG] ストレージのブロック境界が、NVMのブロック境界に揃っていない
         nvm.set_block_size(track!(BlockSize::new(1024))?);
-        assert!(Storage::open(nvm.clone()).is_err());
+        assert!(Storage::open(nvm).is_err());
 
         Ok(())
     }


### PR DESCRIPTION
Clippy's warnings are fixed.
Also, `cargo clippy --lib --tests` will be executed on every CI run.

`clippy`'s version:
```
$ cargo clippy --version
clippy 0.0.212 (bb37a0f9 2020-06-16)
```