### PR TITLE
デバイスの不調を検出できるようにする

### DIFF
--- a/src/device/builder.rs
+++ b/src/device/builder.rs
@@ -2,7 +2,7 @@ use prometrics::metrics::MetricBuilder;
 use std::time::Duration;
 
 use super::thread::DeviceThread;
-use super::{Device, DeviceHandle};
+use super::{failure::FailurePolicy, Device, DeviceHandle};
 use nvm::NonVolatileMemory;
 use slog::{Discard, Logger};
 use storage::Storage;
@@ -17,6 +17,7 @@ pub struct DeviceBuilder {
     pub(crate) max_keep_busy_duration: Duration,
     pub(crate) busy_threshold: usize,
     pub(crate) logger: Logger,
+    pub(crate) failure_policy: FailurePolicy,
 }
 impl DeviceBuilder {
     /// デフォルト設定で`DeviceBuilder`インスタンスを生成する.
@@ -28,6 +29,7 @@ impl DeviceBuilder {
             max_keep_busy_duration: Duration::from_secs(600),
             busy_threshold: 1_000,
             logger: Logger::root(Discard, o!()),
+            failure_policy: FailurePolicy::default(),
         }
     }
 

--- a/src/device/builder.rs
+++ b/src/device/builder.rs
@@ -101,6 +101,12 @@ impl DeviceBuilder {
         self
     }
 
+    /// FailuerPolicy を登録する
+    pub fn failure_policy(&mut self, failure_policy: FailurePolicy) -> &mut Self {
+        self.failure_policy = failure_policy;
+        self
+    }
+
     /// 指定されたストレージを扱う`Device`を起動する.
     ///
     /// 起動したデバイス用に、一つの専用OSスレッドが割り当てられる.

--- a/src/device/execution_observer.rs
+++ b/src/device/execution_observer.rs
@@ -68,6 +68,13 @@ impl ExecutionObserver {
                 self.last_io_duration,
             );
             if self.last_io_duration_sum >= count * average {
+                warn!(
+                    self.logger,
+                    "Requests are taking too long";
+                    "duration_sum" => self.last_io_duration_sum.as_secs_f64(),
+                    "count" => count,
+                    "average" => average.as_secs_f64(),
+                );
                 return true;
             }
         }
@@ -87,6 +94,13 @@ impl ExecutionObserver {
             if self.last_io_errors.len() >= count as usize
                 && last_error - first_error >= self.io_error_threshold.duration
             {
+                warn!(
+                    self.logger,
+                    "Too many errors in a short period";
+                    "difference" => (last_error - first_error).as_secs_f64(),
+                    "count" => count,
+                    "error_threshold_duration" => self.io_error_threshold.duration.as_secs_f64(),
+                );
                 return true;
             }
         }

--- a/src/device/execution_observer.rs
+++ b/src/device/execution_observer.rs
@@ -1,0 +1,122 @@
+use super::failure::{IOErrorThreshold, IOLatencyThreshold};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+#[derive(Debug)]
+pub(crate) struct ExecutionObserver {
+    // 時間の集計。直近 n 回の IO にかかった時間を持つ。
+    io_latency_threshold: IOLatencyThreshold,
+    last_io_duration: VecDeque<Duration>,
+    last_io_duration_sum: Duration,
+
+    // エラー回数の集計。直近 n 回のエラーが起きた時刻を管理する。
+    io_error_threshold: IOErrorThreshold,
+    last_io_errors: VecDeque<Instant>,
+}
+
+impl ExecutionObserver {
+    pub fn new(
+        io_latency_threshold: IOLatencyThreshold,
+        io_error_threshold: IOErrorThreshold,
+    ) -> Self {
+        Self {
+            io_latency_threshold,
+            last_io_duration: VecDeque::new(),
+            last_io_duration_sum: Duration::from_secs(0),
+            io_error_threshold,
+            last_io_errors: VecDeque::new(),
+        }
+    }
+    pub fn observe(&mut self, duration: Duration, time: Instant, has_error: bool) {
+        self.last_io_duration.push_back(duration);
+        self.last_io_duration_sum += duration;
+        while self.last_io_duration.len() > self.io_latency_threshold.count as usize {
+            let first = self.last_io_duration.pop_front().unwrap();
+            self.last_io_duration_sum -= first;
+        }
+        if has_error {
+            self.last_io_errors.push_back(time);
+        }
+        while self.last_io_errors.len() > self.io_error_threshold.count_limit as usize {
+            let _ = self.last_io_errors.pop_front().unwrap();
+        }
+    }
+
+    pub fn is_failing(&self) -> bool {
+        // 時間は ok?
+        if !self.last_io_duration.is_empty() {
+            let count = self.io_latency_threshold.count;
+            let average = self.io_latency_threshold.time_limit;
+            // 直近 count 回の平均が average 以上であれば、true を返す。
+            // IO の回数が count に満たない場合は、確実に今後 count 回で average 以上になる、
+            // つまりすでに count * average だけ時間を消費している場合にエラーを返す。
+            if self.last_io_duration_sum >= count * average {
+                return true;
+            }
+        }
+        // エラー回数は ok?
+        if !self.last_io_errors.is_empty() {
+            let &first_error = self.last_io_errors.front().unwrap();
+            let &last_error = self.last_io_errors.back().unwrap();
+            let count = self.io_error_threshold.count_limit;
+            // もしエラーが count 個以上あって、最初と最後のエラーの間が duration 以下であったならば、エラーが設定値以上の頻度で起きている。
+            if self.last_io_errors.len() >= count as usize
+                && last_error - first_error >= self.io_error_threshold.duration
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_works() {
+        // 10 回の平均が 2 秒以上になったらダメ
+        let io_latency_threshold = IOLatencyThreshold {
+            count: 10,
+            time_limit: Duration::from_secs(2),
+        };
+        // 2 秒間に 10 回以上エラーが起きていたらダメ
+        // 任意の 2 秒間なので、間隔 20/9 秒以下で 10 回連続でエラーが発生したら 2 秒間に 10 回起きた判定になることに注意。
+        let io_error_threshold = IOErrorThreshold {
+            duration: Duration::from_secs(2),
+            count_limit: 10,
+        };
+
+        let mut execution_observer =
+            ExecutionObserver::new(io_latency_threshold.clone(), io_error_threshold.clone());
+        // 2.1 秒かかる I/O を 10 回実行する
+        for _ in 0..10 {
+            execution_observer.observe(Duration::from_millis(2100), Instant::now(), false);
+        }
+        assert!(execution_observer.is_failing());
+
+        let mut execution_observer =
+            ExecutionObserver::new(io_latency_threshold.clone(), io_error_threshold.clone());
+        //  1.9 秒かかる I/O を 10 回実行する
+        for _ in 0..10 {
+            execution_observer.observe(Duration::from_millis(1900), Instant::now(), false);
+        }
+        assert!(!execution_observer.is_failing());
+
+        let mut execution_observer =
+            ExecutionObserver::new(io_latency_threshold, io_error_threshold);
+        // 間隔 2.1 秒 (< 20/9) で 10 回エラーを起こす
+        let now = Instant::now();
+        for i in 0..10 {
+            execution_observer.observe(
+                Duration::from_secs(0),
+                now + Duration::from_millis(2100) * i,
+                true,
+            );
+        }
+        assert!(execution_observer.is_failing());
+    }
+}

--- a/src/device/failure.rs
+++ b/src/device/failure.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+/// How does CannyLS act on failure?
+pub struct FailurePolicy {
+    /// Configuration for IO latencies
+    pub io_latency_threshold: IOLatencyThreshold,
+
+    /// Configuration for IO errors
+    pub io_error_threshold: IOErrorThreshold,
+
+    /// How device errors are handled
+    pub takedown_policy: TakedownPolicy,
+}
+
+/// Configuration for IO latencies
+pub struct IOLatencyThreshold {
+    /// How many operations do we use for averaging?
+    pub count: u64,
+    /// Limit of time consumed. Probably better be Duration.
+    pub time_milli_limit: u64,
+}
+
+/// Configuration for IO errors
+pub struct IOErrorThreshold {
+    /// Limit of the number of failures.
+    pub count_limit: u64,
+    /// Duration during which failures are counted.
+    pub duration: Duration,
+}
+
+/// How device errors are handled
+pub enum TakedownPolicy {
+    /// Stop on error at once
+    Stop,
+    /// hold termination until x failures happen
+    Tolerance(u64),
+    /// Keep running on error
+    Keep,
+}

--- a/src/device/failure.rs
+++ b/src/device/failure.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 /// How does CannyLS act on failure?
+#[derive(Debug, Clone, Default)]
 pub struct FailurePolicy {
     /// Configuration for IO latencies
     pub io_latency_threshold: IOLatencyThreshold,
@@ -13,27 +14,53 @@ pub struct FailurePolicy {
 }
 
 /// Configuration for IO latencies
+#[derive(Debug, Clone)]
 pub struct IOLatencyThreshold {
     /// How many operations do we use for averaging?
-    pub count: u64,
-    /// Limit of time consumed. Probably better be Duration.
-    pub time_milli_limit: u64,
+    pub count: u32,
+    /// Limit of time consumed.
+    pub time_limit: Duration,
+}
+
+impl Default for IOLatencyThreshold {
+    fn default() -> Self {
+        Self {
+            count: 100,
+            time_limit: Duration::from_millis(200),
+        }
+    }
 }
 
 /// Configuration for IO errors
+#[derive(Debug, Clone)]
 pub struct IOErrorThreshold {
     /// Limit of the number of failures.
-    pub count_limit: u64,
+    pub count_limit: u32,
     /// Duration during which failures are counted.
     pub duration: Duration,
 }
 
+impl Default for IOErrorThreshold {
+    fn default() -> Self {
+        Self {
+            count_limit: 2,
+            duration: Duration::from_millis(1000),
+        }
+    }
+}
 /// How device errors are handled
+#[derive(Debug, Clone)]
 pub enum TakedownPolicy {
     /// Stop on error at once
     Stop,
     /// hold termination until x failures happen
-    Tolerance(u64),
+    Tolerate(u64),
     /// Keep running on error
     Keep,
+}
+
+impl Default for TakedownPolicy {
+    fn default() -> Self {
+        Self::Keep
+    }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -15,6 +15,7 @@ use futures::{Async, Future, Poll};
 use std::sync::Arc;
 
 pub use self::builder::DeviceBuilder;
+pub use self::failure::{FailurePolicy, IOErrorThreshold, IOLatencyThreshold};
 pub use self::request::DeviceRequest;
 
 pub(crate) use self::command::Command; // `metrics`モジュール用に公開されている
@@ -31,7 +32,7 @@ mod builder;
 mod command;
 mod execution_observer;
 /// A module that contains failure-related structs/enums.
-pub mod failure;
+mod failure;
 mod queue;
 mod request;
 mod thread;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -29,6 +29,8 @@ use {Error, Result};
 
 mod builder;
 mod command;
+/// A module that contains failure-related structs/enums.
+pub mod failure;
 mod queue;
 mod request;
 mod thread;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -29,6 +29,7 @@ use {Error, Result};
 
 mod builder;
 mod command;
+mod execution_observer;
 /// A module that contains failure-related structs/enums.
 pub mod failure;
 mod queue;

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -81,10 +81,10 @@ where
                         builder.failure_policy.io_error_threshold.clone(),
                     ),
                 };
+                // 実装を簡単にするため、どんな場合もエラーの回数は覚えておく
+                let mut error_count: u64 = 0;
                 loop {
                     // takedown_policy に応じて、エラー時にどうするか決める
-                    // 実装を簡単にするため、どんな場合もエラーの回数は覚えておく
-                    let mut error_count: u64 = 0;
                     match track!(device.run_once()) {
                         Err(e) => {
                             error_count += 1;

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -74,8 +74,9 @@ where
                     start_busy_time: None,
                     command_tx,
                     command_rx,
-                    logger: builder.logger,
+                    logger: builder.logger.clone(),
                     execution_observer: ExecutionObserver::new(
+                        builder.logger,
                         builder.failure_policy.io_latency_threshold.clone(),
                         builder.failure_policy.io_error_threshold.clone(),
                     ),

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -8,6 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 use trackable::error::ErrorKindExt;
 
+use super::execution_observer::ExecutionObserver;
+use super::failure::TakedownPolicy;
 use device::command::{Command, CommandReceiver, CommandSender};
 use device::queue::DeadlineQueue;
 use device::{DeviceBuilder, DeviceStatus};
@@ -33,6 +35,7 @@ where
     command_tx: CommandSender,
     command_rx: CommandReceiver,
     logger: Logger,
+    execution_observer: ExecutionObserver,
 }
 impl<N> DeviceThread<N>
 where
@@ -59,6 +62,7 @@ where
             let result = track!(init_storage()).and_then(|storage| {
                 metrics.storage = Some(storage.metrics().clone());
                 metrics.status.set(f64::from(DeviceStatus::Running as u8));
+                let takedown_policy = builder.failure_policy.takedown_policy;
                 let mut device = DeviceThread {
                     metrics: metrics.clone(),
                     queue: DeadlineQueue::new(),
@@ -71,10 +75,28 @@ where
                     command_tx,
                     command_rx,
                     logger: builder.logger,
+                    execution_observer: ExecutionObserver::new(
+                        builder.failure_policy.io_latency_threshold.clone(),
+                        builder.failure_policy.io_error_threshold.clone(),
+                    ),
                 };
                 loop {
+                    // takedown_policy に応じて、エラー時にどうするか決める
+                    // 実装を簡単にするため、どんな場合もエラーの回数は覚えておく
+                    let mut error_count: u64 = 0;
                     match track!(device.run_once()) {
-                        Err(e) => break Err(e),
+                        Err(e) => {
+                            error_count += 1;
+                            match &takedown_policy {
+                                &TakedownPolicy::Stop => break Err(e),
+                                &TakedownPolicy::Tolerate(limit) => {
+                                    if error_count >= limit {
+                                        break Err(e);
+                                    }
+                                }
+                                &TakedownPolicy::Keep => {}
+                            }
+                        }
                         Ok(false) => break Ok(()),
                         Ok(true) => {}
                     }
@@ -96,7 +118,14 @@ where
         } else if let Some(command) = self.queue.pop() {
             track!(self.check_overload())?;
             self.metrics.dequeued_commands.increment(&command);
-            track!(self.handle_command(command))
+            let result = track!(self.handle_command(command))?;
+            if self.execution_observer.is_failing() {
+                warn!(self.logger, "execution_observer says it's failing!");
+                return Err(ErrorKind::Other
+                    .cause("execution_observer says it's failing!")
+                    .into());
+            }
+            Ok(result)
         } else {
             match self.command_rx.recv_timeout(self.idle_threshold) {
                 Err(RecvTimeoutError::Disconnected) => unreachable!(),
@@ -114,13 +143,23 @@ where
         }
     }
 
+    /// Ok(true) を返す -> スレッド続行
+    /// Ok(false) を返す -> スレッド正常終了
+    /// Err(...) を返す -> スレッド異常終了
     fn handle_command(&mut self, command: Command) -> Result<bool> {
         match command {
             Command::Get(c) => {
+                // time here
+                let now = Instant::now();
                 let result = track!(self.storage.get(c.lump_id()));
+                let elapsed = now.elapsed();
                 if result.is_err() {
                     self.metrics.failed_commands.get.increment();
                 }
+                // record here
+                debug!(self.logger, "execution_observer is recording... (read)");
+                self.execution_observer
+                    .observe(elapsed, now, result.is_err());
                 c.reply(result);
                 Ok(true)
             }
@@ -141,10 +180,18 @@ where
             }
             Command::Put(c) => {
                 debug!(self.logger, "Put LumpId=(\"{}\")", c.lump_id());
+                // time here
+                let now = Instant::now();
                 let result = track!(self.storage.put(c.lump_id(), c.lump_data()));
+                let elapsed = now.elapsed();
                 if result.is_err() {
                     self.metrics.failed_commands.put.increment();
                 }
+                // record time
+                debug!(self.logger, "execution_observer is recording... (write)");
+                self.execution_observer
+                    .observe(elapsed, now, result.is_err());
+
                 if let Some(e) = maybe_critical_error(&result) {
                     c.reply(result);
                     Err(e)
@@ -160,10 +207,17 @@ where
                 }
             }
             Command::Delete(c) => {
+                // time here
+                let now = Instant::now();
                 let result = track!(self.storage.delete(c.lump_id()));
+                let elapsed = now.elapsed();
                 if result.is_err() {
                     self.metrics.failed_commands.delete.increment();
                 }
+                // record here
+                debug!(self.logger, "execution_observer is recording... (delete)");
+                self.execution_observer
+                    .observe(elapsed, now, result.is_err());
                 if let Some(e) = maybe_critical_error(&result) {
                     c.reply(result);
                     Err(e)
@@ -179,10 +233,20 @@ where
                 }
             }
             Command::DeleteRange(c) => {
+                // time here
+                let now = Instant::now();
                 let result = track!(self.storage.delete_range(c.lump_range()));
+                let elapsed = now.elapsed();
                 if result.is_err() {
                     self.metrics.failed_commands.delete_range.increment();
                 }
+                // record here
+                debug!(
+                    self.logger,
+                    "execution_observer is recording... (delete_range)",
+                );
+                self.execution_observer
+                    .observe(elapsed, now, result.is_err());
                 if let Some(e) = maybe_critical_error(&result) {
                     c.reply(result);
                     Err(e)

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -89,13 +89,13 @@ where
                         Err(e) => {
                             error_count += 1;
                             match &takedown_policy {
-                                &TakedownPolicy::Stop => break Err(e),
-                                &TakedownPolicy::Tolerate(limit) => {
-                                    if error_count >= limit {
+                                TakedownPolicy::Stop => break Err(e),
+                                TakedownPolicy::Tolerate(limit) => {
+                                    if error_count >= *limit {
                                         break Err(e);
                                     }
                                 }
-                                &TakedownPolicy::Keep => {}
+                                TakedownPolicy::Keep => {}
                             }
                         }
                         Ok(false) => break Ok(()),


### PR DESCRIPTION
デバイスの不調の兆候を検出して、対応ができるようにします。
以下の兆候を検出します:
(1) I/O のレイテンシ増大。具体的には、x 回の I/O にかかる時間が y 秒以上であれば不調と判定する。
(2) I/O エラー増加。具体的には、x 秒以内に I/O エラーが x 回以上起起これば不調と判定する。

また、不調と判定した後、対応として以下が選択できます:
(1) すぐにデバイスを止める
(2) n 回までは耐える
(3) 無視してそのままデバイスを動かす (止めるのであれば手動でデバイスを止める想定)