### PR TITLE
キューが長くなった時の対応を追加する

### DIFF
--- a/src/device/builder.rs
+++ b/src/device/builder.rs
@@ -1,6 +1,7 @@
 use prometrics::metrics::MetricBuilder;
 use std::time::Duration;
 
+use super::long_queue_policy::LongQueuePolicy;
 use super::thread::DeviceThread;
 use super::{Device, DeviceHandle};
 use nvm::NonVolatileMemory;
@@ -17,6 +18,7 @@ pub struct DeviceBuilder {
     pub(crate) max_keep_busy_duration: Duration,
     pub(crate) busy_threshold: usize,
     pub(crate) logger: Logger,
+    pub(crate) long_queue_policy: LongQueuePolicy,
 }
 impl DeviceBuilder {
     /// デフォルト設定で`DeviceBuilder`インスタンスを生成する.
@@ -28,6 +30,7 @@ impl DeviceBuilder {
             max_keep_busy_duration: Duration::from_secs(600),
             busy_threshold: 1_000,
             logger: Logger::root(Discard, o!()),
+            long_queue_policy: LongQueuePolicy::default(),
         }
     }
 
@@ -96,6 +99,12 @@ impl DeviceBuilder {
     /// デバイススレッド用の logger を登録する
     pub fn logger(&mut self, logger: Logger) -> &mut Self {
         self.logger = logger;
+        self
+    }
+
+    /// LongQueuePolicy を登録する
+    pub fn long_queue_policy(&mut self, long_queue_policy: LongQueuePolicy) -> &mut Self {
+        self.long_queue_policy = long_queue_policy;
         self
     }
 

--- a/src/device/command.rs
+++ b/src/device/command.rs
@@ -39,6 +39,19 @@ impl Command {
             Command::Stop(ref c) => c.deadline,
         }
     }
+    pub fn prioritized(&self) -> bool {
+        match *self {
+            Command::Put(ref c) => c.prioritized,
+            Command::Get(ref c) => c.prioritized,
+            Command::Head(ref c) => c.prioritized,
+            Command::Delete(ref c) => c.prioritized,
+            Command::DeleteRange(ref c) => c.prioritized,
+            Command::List(ref c) => c.prioritized,
+            Command::ListRange(ref c) => c.prioritized,
+            Command::UsageRange(ref c) => c.prioritized,
+            Command::Stop(ref c) => c.prioritized,
+        }
+    }
     pub fn failed(self, error: Error) {
         match self {
             Command::Put(c) => c.reply.send(Err(error)),

--- a/src/device/command.rs
+++ b/src/device/command.rs
@@ -90,6 +90,7 @@ pub struct PutLump {
     lump_id: LumpId,
     lump_data: LumpData,
     deadline: Deadline,
+    prioritized: bool,
     journal_sync: bool,
     reply: AsyncReply<bool>,
 }
@@ -99,6 +100,7 @@ impl PutLump {
         lump_id: LumpId,
         lump_data: LumpData,
         deadline: Deadline,
+        prioritized: bool,
         journal_sync: bool,
     ) -> (Self, AsyncResult<bool>) {
         let (reply, result) = AsyncResult::new();
@@ -106,6 +108,7 @@ impl PutLump {
             lump_id,
             lump_data,
             deadline,
+            prioritized,
             journal_sync,
             reply,
         };
@@ -130,15 +133,21 @@ impl PutLump {
 pub struct GetLump {
     lump_id: LumpId,
     deadline: Deadline,
+    prioritized: bool,
     reply: AsyncReply<Option<LumpData>>,
 }
 impl GetLump {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(lump_id: LumpId, deadline: Deadline) -> (Self, AsyncResult<Option<LumpData>>) {
+    pub fn new(
+        lump_id: LumpId,
+        deadline: Deadline,
+        prioritized: bool,
+    ) -> (Self, AsyncResult<Option<LumpData>>) {
         let (reply, result) = AsyncResult::new();
         let command = GetLump {
             lump_id,
             deadline,
+            prioritized,
             reply,
         };
         (command, result)
@@ -155,15 +164,21 @@ impl GetLump {
 pub struct HeadLump {
     lump_id: LumpId,
     deadline: Deadline,
+    prioritized: bool,
     reply: AsyncReply<Option<LumpHeader>>,
 }
 impl HeadLump {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(lump_id: LumpId, deadline: Deadline) -> (Self, AsyncResult<Option<LumpHeader>>) {
+    pub fn new(
+        lump_id: LumpId,
+        deadline: Deadline,
+        prioritized: bool,
+    ) -> (Self, AsyncResult<Option<LumpHeader>>) {
         let (reply, result) = AsyncResult::new();
         let command = HeadLump {
             lump_id,
             deadline,
+            prioritized,
             reply,
         };
         (command, result)
@@ -180,6 +195,7 @@ impl HeadLump {
 pub struct DeleteLump {
     lump_id: LumpId,
     deadline: Deadline,
+    prioritized: bool,
     journal_sync: bool,
     reply: AsyncReply<bool>,
 }
@@ -188,12 +204,14 @@ impl DeleteLump {
     pub fn new(
         lump_id: LumpId,
         deadline: Deadline,
+        prioritized: bool,
         journal_sync: bool,
     ) -> (Self, AsyncResult<bool>) {
         let (reply, result) = AsyncResult::new();
         let command = DeleteLump {
             lump_id,
             deadline,
+            prioritized,
             journal_sync,
             reply,
         };
@@ -214,6 +232,7 @@ impl DeleteLump {
 pub struct DeleteLumpRange {
     range: Range<LumpId>,
     deadline: Deadline,
+    prioritized: bool,
     journal_sync: bool,
     reply: AsyncReply<Vec<LumpId>>,
 }
@@ -222,12 +241,14 @@ impl DeleteLumpRange {
     pub fn new(
         range: Range<LumpId>,
         deadline: Deadline,
+        prioritized: bool,
         journal_sync: bool,
     ) -> (Self, AsyncResult<Vec<LumpId>>) {
         let (reply, result) = AsyncResult::new();
         let command = DeleteLumpRange {
             range,
             deadline,
+            prioritized,
             journal_sync,
             reply,
         };
@@ -247,13 +268,18 @@ impl DeleteLumpRange {
 #[derive(Debug)]
 pub struct ListLump {
     deadline: Deadline,
+    prioritized: bool,
     reply: AsyncReply<Vec<LumpId>>,
 }
 impl ListLump {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(deadline: Deadline) -> (Self, AsyncResult<Vec<LumpId>>) {
+    pub fn new(deadline: Deadline, prioritized: bool) -> (Self, AsyncResult<Vec<LumpId>>) {
         let (reply, result) = AsyncResult::new();
-        let command = ListLump { deadline, reply };
+        let command = ListLump {
+            deadline,
+            prioritized,
+            reply,
+        };
         (command, result)
     }
     pub fn reply(self, result: Result<Vec<LumpId>>) {
@@ -265,15 +291,21 @@ impl ListLump {
 pub struct ListLumpRange {
     range: Range<LumpId>,
     deadline: Deadline,
+    prioritized: bool,
     reply: AsyncReply<Vec<LumpId>>,
 }
 impl ListLumpRange {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(range: Range<LumpId>, deadline: Deadline) -> (Self, AsyncResult<Vec<LumpId>>) {
+    pub fn new(
+        range: Range<LumpId>,
+        deadline: Deadline,
+        prioritized: bool,
+    ) -> (Self, AsyncResult<Vec<LumpId>>) {
         let (reply, result) = AsyncResult::new();
         let command = ListLumpRange {
             range,
             deadline,
+            prioritized,
             reply,
         };
         (command, result)
@@ -290,15 +322,21 @@ impl ListLumpRange {
 pub struct UsageLumpRange {
     range: Range<LumpId>,
     deadline: Deadline,
+    prioritized: bool,
     reply: AsyncReply<StorageUsage>,
 }
 impl UsageLumpRange {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(range: Range<LumpId>, deadline: Deadline) -> (Self, AsyncResult<StorageUsage>) {
+    pub fn new(
+        range: Range<LumpId>,
+        deadline: Deadline,
+        prioritized: bool,
+    ) -> (Self, AsyncResult<StorageUsage>) {
         let (reply, result) = AsyncResult::new();
         let command = UsageLumpRange {
             range,
             deadline,
+            prioritized,
             reply,
         };
         (command, result)
@@ -314,9 +352,13 @@ impl UsageLumpRange {
 #[derive(Debug)]
 pub struct StopDevice {
     deadline: Deadline,
+    prioritized: bool,
 }
 impl StopDevice {
-    pub fn new(deadline: Deadline) -> Self {
-        StopDevice { deadline }
+    pub fn new(deadline: Deadline, prioritized: bool) -> Self {
+        StopDevice {
+            deadline,
+            prioritized,
+        }
     }
 }

--- a/src/device/long_queue_policy.rs
+++ b/src/device/long_queue_policy.rs
@@ -1,0 +1,27 @@
+/// デバイスのキューが長い場合にどうするか
+/// default は RefuseNewRequests
+#[derive(Debug, Clone)]
+pub enum LongQueuePolicy {
+    /// 新しいリクエストを拒否する
+    RefuseNewRequests,
+
+    /// デバイスを止める
+    Stop,
+
+    /// 一定の割合でリクエストをドロップする。
+    ///
+    /// ratio としてドロップ率 (0 以上 1 以下) を決める。
+    /// 本当はもっと柔軟にやったほうがいいかもしれないが、当面固定値で問題ないだろうと思われる。
+    ///
+    /// TODO: ドロップ率を真面目に計算する
+    Drop {
+        /// ドロップ率
+        ratio: f64,
+    },
+}
+
+impl Default for LongQueuePolicy {
+    fn default() -> Self {
+        LongQueuePolicy::RefuseNewRequests
+    }
+}

--- a/src/device/long_queue_policy.rs
+++ b/src/device/long_queue_policy.rs
@@ -1,6 +1,6 @@
 /// デバイスのキューが長い場合にどうするか
 /// default は RefuseNewRequests
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LongQueuePolicy {
     /// 一定の割合で新しいリクエストを拒否する
     ///

--- a/src/device/long_queue_policy.rs
+++ b/src/device/long_queue_policy.rs
@@ -33,3 +33,15 @@ impl Default for LongQueuePolicy {
         LongQueuePolicy::RefuseNewRequests { ratio: 1.0 }
     }
 }
+
+impl LongQueuePolicy {
+    /// 過負荷時にリクエストが実行されない確率を返す。
+    /// 「実行されない」は、「拒否される」あるいは「ドロップされる」のいずれかを意味する。
+    pub fn ratio(&self) -> f64 {
+        match *self {
+            LongQueuePolicy::RefuseNewRequests { ratio } => ratio,
+            LongQueuePolicy::Stop => 0.0,
+            LongQueuePolicy::Drop { ratio } => ratio,
+        }
+    }
+}

--- a/src/device/long_queue_policy.rs
+++ b/src/device/long_queue_policy.rs
@@ -30,7 +30,7 @@ pub enum LongQueuePolicy {
 
 impl Default for LongQueuePolicy {
     fn default() -> Self {
-        LongQueuePolicy::RefuseNewRequests { ratio: 1.0 }
+        LongQueuePolicy::Stop
     }
 }
 

--- a/src/device/long_queue_policy.rs
+++ b/src/device/long_queue_policy.rs
@@ -2,8 +2,16 @@
 /// default は RefuseNewRequests
 #[derive(Debug, Clone)]
 pub enum LongQueuePolicy {
-    /// 新しいリクエストを拒否する
-    RefuseNewRequests,
+    /// 一定の割合で新しいリクエストを拒否する
+    ///
+    /// ratio として拒否率 (0 以上 1 以下) を決める。
+    /// 本当はもっと柔軟にやったほうがいいかもしれないが、当面固定値で問題ないだろうと思われる。
+    ///
+    /// TODO: 拒否率を真面目に計算する
+    RefuseNewRequests {
+        /// 拒否率
+        ratio: f64,
+    },
 
     /// デバイスを止める
     Stop,
@@ -22,6 +30,6 @@ pub enum LongQueuePolicy {
 
 impl Default for LongQueuePolicy {
     fn default() -> Self {
-        LongQueuePolicy::RefuseNewRequests
+        LongQueuePolicy::RefuseNewRequests { ratio: 1.0 }
     }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -546,6 +546,7 @@ mod tests {
 
     #[test]
     fn device_long_queue_policy_refuse_request_works() -> TestResult {
+        // TODO: better testing
         let nvm = MemoryNvm::new(vec![0; 1024 * 1024]);
         let storage = track!(Storage::create(nvm))?;
         let device = DeviceBuilder::new()
@@ -555,7 +556,8 @@ mod tests {
             .spawn(|| Ok(storage));
 
         let handle = device.handle();
-        // 1 回目は成功する
+        // 1 回目は成功する。これは、拒否の判定タイミングがキューにリクエストを積む時で、その時初めて check_overload が呼ばれるため。
+        // check_overload の初回呼び出しは決してエラーを返さない。
         let result = execute(
             handle
                 .request()

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -15,6 +15,7 @@ use futures::{Async, Future, Poll};
 use std::sync::Arc;
 
 pub use self::builder::DeviceBuilder;
+pub use self::long_queue_policy::LongQueuePolicy;
 pub use self::request::DeviceRequest;
 
 pub(crate) use self::command::Command; // `metrics`モジュール用に公開されている
@@ -29,6 +30,8 @@ use {Error, Result};
 
 mod builder;
 mod command;
+mod long_queue_policy;
+mod probabilistic;
 mod queue;
 mod request;
 mod thread;

--- a/src/device/probabilistic.rs
+++ b/src/device/probabilistic.rs
@@ -1,0 +1,38 @@
+use std::fmt::Debug;
+
+/// リクエストを落としたり落とさなかったりする決定を下すオブジェクト。
+pub(crate) trait Dropper: Debug {
+    /// 次のリクエストを落とすなら true、落とさないなら false。
+    /// 内部状態の変更も許されることに注意。
+    fn will_drop(&mut self) -> bool;
+}
+
+/// あらかじめ指定した確率で落とす判定をする Dropper。
+#[derive(Debug)]
+pub(crate) struct ProbabilisticDropper {
+    ratio: f64,
+    counter: f64,
+}
+
+impl ProbabilisticDropper {
+    pub fn new(ratio: f64) -> Self {
+        Self {
+            ratio,
+            counter: 0.0,
+        }
+    }
+}
+
+impl Dropper for ProbabilisticDropper {
+    fn will_drop(&mut self) -> bool {
+        self.counter += self.ratio;
+        // counter >= 1 であれば、counter -= 1 を行って落とす。
+        // 毎回 counter が ratio だけ増えて、たまに 1 減るので、counter の大きさがそこまで変わらないため
+        // 1 減る回数の割合は ratio に収束する。
+        if self.counter >= 1.0 {
+            self.counter -= 1.0;
+            return true;
+        }
+        false
+    }
+}

--- a/src/device/probabilistic.rs
+++ b/src/device/probabilistic.rs
@@ -1,3 +1,4 @@
+use slog::Logger;
 use std::fmt::Debug;
 
 /// リクエストを落としたり落とさなかったりする決定を下すオブジェクト。
@@ -10,13 +11,15 @@ pub(crate) trait Dropper: Debug {
 /// あらかじめ指定した確率で落とす判定をする Dropper。
 #[derive(Debug)]
 pub(crate) struct ProbabilisticDropper {
+    logger: Logger,
     ratio: f64,
     counter: f64,
 }
 
 impl ProbabilisticDropper {
-    pub fn new(ratio: f64) -> Self {
+    pub fn new(logger: Logger, ratio: f64) -> Self {
         Self {
+            logger,
             ratio,
             counter: 0.0,
         }
@@ -25,10 +28,12 @@ impl ProbabilisticDropper {
 
 impl Dropper for ProbabilisticDropper {
     fn will_drop(&mut self) -> bool {
+        debug!(self.logger, "old counter = {}",self.counter; "ratio" => self.ratio);
         self.counter += self.ratio;
         // counter >= 1 であれば、counter -= 1 を行って落とす。
         // 毎回 counter が ratio だけ増えて、たまに 1 減るので、counter の大きさがそこまで変わらないため
         // 1 減る回数の割合は ratio に収束する。
+        debug!(self.logger, "new counter = {}", self.counter; "ratio" => self.ratio);
         if self.counter >= 1.0 {
             self.counter -= 1.0;
             return true;

--- a/src/device/probabilistic.rs
+++ b/src/device/probabilistic.rs
@@ -46,10 +46,13 @@ impl Dropper for ProbabilisticDropper {
 mod tests {
     use super::*;
 
+    use slog::Discard;
+
     #[test]
     fn probabilistic_dropper_works() {
+        let logger = Logger::root(Discard, o!());
         let ratio = 0.3;
-        let mut dropper = ProbabilisticDropper::new(ratio);
+        let mut dropper = ProbabilisticDropper::new(logger, ratio);
         let n = 10000;
         // n 回実行しておよそ 3 割のリクエストが drop されることを確かめる。
         let mut dropped = 0;

--- a/src/device/probabilistic.rs
+++ b/src/device/probabilistic.rs
@@ -36,3 +36,24 @@ impl Dropper for ProbabilisticDropper {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probabilistic_dropper_works() {
+        let ratio = 0.3;
+        let mut dropper = ProbabilisticDropper::new(ratio);
+        let n = 10000;
+        // n 回実行しておよそ 3 割のリクエストが drop されることを確かめる。
+        let mut dropped = 0;
+        for _ in 0..n {
+            if dropper.will_drop() {
+                dropped += 1;
+            }
+        }
+        assert!(2900 < dropped);
+        assert!(dropped < 3100);
+    }
+}

--- a/src/device/queue.rs
+++ b/src/device/queue.rs
@@ -128,7 +128,7 @@ mod tests {
     }
 
     fn command(lump_id: u128, deadline: Deadline) -> Command {
-        Command::Get(GetLump::new(LumpId::new(lump_id), deadline).0)
+        Command::Get(GetLump::new(LumpId::new(lump_id), deadline, false).0)
     }
 
     fn lump_id(command: Option<Command>) -> Option<u128> {

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -66,11 +66,7 @@ where
                 metrics.status.set(f64::from(DeviceStatus::Running as u8));
                 // LongQueuePolicy が RefuseNewRequests か Drop だったら、この後 run_once で使うため、dropper を作っておく。
                 // Stop の場合も実装を簡単にするためにプレイスホルダーの dropper を作る。
-                let ratio = match builder.long_queue_policy {
-                    LongQueuePolicy::RefuseNewRequests { ratio } => ratio,
-                    LongQueuePolicy::Stop => 0.0,
-                    LongQueuePolicy::Drop { ratio } => ratio,
-                };
+                let ratio = builder.long_queue_policy.ratio();
                 let dropper = Box::new(ProbabilisticDropper::new(builder.logger.clone(), ratio))
                     as Box<dyn Dropper>;
                 let mut device = DeviceThread {

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -292,6 +292,7 @@ where
     // command に対し、常に指定されたエラーを返答する。
     // この関数自身は常に成功するため、handle_command と違い bool を返す。
     fn handle_command_with_error(&mut self, command: Command, error: Error) -> bool {
+        self.metrics.failed_commands.increment(&command);
         match command {
             Command::Get(c) => c.reply(track!(Err(error))),
             Command::Head(c) => c.reply(track!(Err(error))),

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -117,7 +117,14 @@ where
                     LongQueuePolicy::Drop { .. } => {
                         // 確率 ratio で drop する
                         if self.dropper.as_mut().unwrap().will_drop() {
-                            info!(self.logger, "Request dropped: {:?}", command; "queue_len" => self.queue.len());
+                            let elapsed = self.start_busy_time.map(|t| t.elapsed().as_secs());
+                            info!(
+                                self.logger,
+                                "Request dropped: {:?}",
+                                command;
+                                "queue_len" => self.queue.len(),
+                                "from_busy (sec)" => elapsed,
+                            );
                             self.metrics.dequeued_commands.increment(&command);
                             let result = self.handle_command_with_error(
                                 command,
@@ -149,7 +156,13 @@ where
         if let Err(e) = result {
             match &self.long_queue_policy {
                 LongQueuePolicy::RefuseNewRequests => {
-                    info!(self.logger, "Request refused: {:?}", command; "queue_len" => self.queue.len());
+                    let elapsed = self.start_busy_time.map(|t| t.elapsed().as_secs());
+                    info!(
+                        self.logger, "Request refused: {:?}",
+                        command;
+                        "queue_len" => self.queue.len(),
+                        "from_busy (sec)" => elapsed,
+                    );
                     self.metrics.dequeued_commands.increment(&command);
                     let result = self.handle_command_with_error(
                         command,

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -115,7 +115,9 @@ where
             if let Err(e) = result {
                 match &self.long_queue_policy {
                     LongQueuePolicy::RefuseNewRequests => {
-                        info!(self.logger, "Request refused: {:?}", command);
+                        // TODO: 現在の挙動は drop (drop 率 100%) と変わらない。
+                        // 本来の挙動は、キューに積もうとするときに拒否するというものなので、別の場所に実装する必要がある。
+                        info!(self.logger, "Request refused: {:?}", command; "queue_len" => self.queue.len());
                         let result = self.handle_command_with_error(
                             command,
                             ErrorKind::Other.cause("refused").into(),
@@ -126,7 +128,7 @@ where
                     LongQueuePolicy::Drop { .. } => {
                         // 確率 ratio で drop する
                         if self.dropper.as_mut().unwrap().will_drop() {
-                            info!(self.logger, "Request dropped: {:?}", command);
+                            info!(self.logger, "Request dropped: {:?}", command; "queue_len" => self.queue.len());
                             let result = self.handle_command_with_error(
                                 command,
                                 ErrorKind::Other.cause("dropped").into(),


### PR DESCRIPTION
以下の (1)(2) の2種類の機能が追加される。

### (1) キュー長が長くなった時にリクエストをどうするか決められるようにする
device thread (frugalos のデバイスに対応する) 毎に、リクエストキューの長さ xxx 以上が yy 秒以上続いたら対処を開始する。
(デフォルト値: xxx = 1000, yy = 600)
以下の 3 種類の対応のうちどれかを選ぶことができる:

1. 新しいリクエストを refuse する
2. device thread を落とす (この PR 以前の挙動)
3. 今処理しているリクエストを一定確率で drop する。

### (2) (1) の対応を、重要なリクエストに対して行わない
DeviceRequest に新たに `prioritized` というフィールドを追加した。これが有効になっているリクエストについては、(1) で説明した対処は行われず、キュー長が別に設定された hard limit (`max_queue_len`) を上回った場合にのみ失敗するようにする。
- 導入の背景: frugalos は失敗されると困るリクエストを投げる。 例えば segment node の選挙関係の GET/PUT は、失敗したら node が落ちる。
- hard limit 導入の理由: あまりにキューが長くなりすぎるとメモリを大量に消費してしまい、例えば上の場合だと segment node が落ちた方がマシという状態になるため。

## TODO
- [ ] ~~log で command を直接出すと (特に PUT されるデータが print されるので) 遅くなりかねない~~ `impl Debug for LumpData` の仕様で長い場合は省略されるので問題ない
- [x] refuse の処理を que.pop() 時ではなく que.push() 時にやる必要あり
- [x] prioritized を見て thread.rs でドロップしたりしなかったりする (キュー長の hard limit も考慮する)
