### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/block/aligned_bytes.rs
+++ b/src/block/aligned_bytes.rs
@@ -125,11 +125,9 @@ impl Clone for AlignedBytes {
 }
 
 fn alignment_offset(buf: &[u8], block_size: BlockSize) -> usize {
-    unsafe {
-        let ptr_usize: usize = std::mem::transmute(buf.as_ptr());
-        let aligned_ptr_usize = block_size.ceil_align(ptr_usize as u64) as usize;
-        aligned_ptr_usize - ptr_usize
-    }
+    let ptr_usize: usize = buf.as_ptr() as usize;
+    let aligned_ptr_usize = block_size.ceil_align(ptr_usize as u64) as usize;
+    aligned_ptr_usize - ptr_usize
 }
 
 #[cfg(test)]

--- a/src/storage/allocator/data_portion_allocator.rs
+++ b/src/storage/allocator/data_portion_allocator.rs
@@ -66,7 +66,7 @@ impl DataPortionAllocator {
         portions.push(sentinel);
         // DataPortionの終端を用いて降順ソートを行う。
         // すなわち、ソート後は、先頭であればあるほどend()の値は大きい。
-        portions.sort_by(|a: &DataPortion, b: &DataPortion| b.end().cmp(&a.end()));
+        portions.sort_by_key(|&b| std::cmp::Reverse(b.end()));
 
         // 変数tailの意味は次の通り:
         // tail位置には値が書き込めない・書き込まれている、すなわち空いてはいない。


### PR DESCRIPTION
This PR addresses new lints introduced in the latest clippy (1.46.0).

Two issues are addressed:

1. https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
2. https://rust-lang.github.io/rust-clippy/master/index.html#transmutes_expressible_as_ptr_casts
Although as of now this lint is only included in the current beta, casting by `transmute`-ing introduces an unnecessary `unsafe` block, and will be likely to be included in the next clippy version. Therefore I fixed it.

`clippy`'s version:
```
$ cargo clippy --version
clippy 0.0.212 (04488afe3 2020-08-24)
```