### PR TITLE
Opt-out device and futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,27 @@ license = "MIT"
 [badges]
 travis-ci = {repository = "frugalos/cannyls"}
 
+[features]
+default = ["futures", "fibers"]
+
+device = ["futures", "fibers"]
+
 [dependencies]
 adler32 = "1"
 byteorder = { version = "1", features = ["i128"] }
-fibers = "0.1"
-futures = "0.1"
 libc = "0.2"
 prometrics = "0.1"
 trackable = "0.2"
 uuid = { version = "0.7", features = ["v4"] }
 slog = "2"
+
+[dependencies.futures]
+version = "0.1"
+optional = true
+
+[dependencies.fibers]
+version = "0.1"
+optional = true
 
 [dev-dependencies]
 fibers_global = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@
 #![warn(missing_docs)]
 extern crate adler32;
 extern crate byteorder;
-extern crate fibers;
 #[cfg(test)]
 extern crate fibers_global;
+#[cfg(feature = "device")]
 extern crate futures;
 extern crate libc;
 extern crate prometrics;
@@ -68,6 +68,7 @@ extern crate tempdir;
 extern crate trackable;
 extern crate uuid;
 #[macro_use]
+#[cfg(feature = "device")]
 extern crate slog;
 
 pub use crate::error::{Error, ErrorKind};
@@ -80,6 +81,7 @@ macro_rules! track_io {
 
 pub mod block;
 pub mod deadline;
+#[cfg(feature = "device")]
 pub mod device;
 pub mod lump;
 pub mod metrics;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,6 +4,7 @@
 use prometrics::metrics::{Counter, Gauge, MetricBuilder};
 
 use crate::block::BlockSize;
+#[cfg(feature = "device")]
 use crate::device::{Command, DeviceStatus};
 use crate::storage::{JournalRecord, StorageHeader};
 
@@ -492,6 +493,7 @@ impl DataAllocatorMetrics {
 /// [`Device`]のメトリクス.
 ///
 /// [`Device`]: ../device/struct.Device.html
+#[cfg(feature = "device")]
 #[derive(Debug, Clone)]
 pub struct DeviceMetrics {
     pub(crate) status: Gauge,
@@ -502,6 +504,7 @@ pub struct DeviceMetrics {
     pub(crate) side_jobs: Counter,
     pub(crate) storage: Option<StorageMetrics>,
 }
+#[cfg(feature = "device")]
 impl DeviceMetrics {
     /// デバイスの稼働状態.
     ///
@@ -513,6 +516,7 @@ impl DeviceMetrics {
     /// # 2=running
     /// cannyls_device_status = 0|1|2
     /// ```
+    #[cfg(feature = "device")]
     pub fn status(&self) -> DeviceStatus {
         match self.status.value() as u8 {
             0 => DeviceStatus::Stopped,
@@ -658,6 +662,7 @@ impl DeviceMetrics {
 }
 
 /// デバイスのコマンド毎のカウンタ.
+#[cfg(feature = "device")]
 #[derive(Debug, Clone)]
 pub struct DeviceCommandCounter {
     pub(crate) put: Counter,
@@ -670,6 +675,7 @@ pub struct DeviceCommandCounter {
     pub(crate) usage_range: Counter,
     pub(crate) stop: Counter,
 }
+#[cfg(feature = "device")]
 impl DeviceCommandCounter {
     /// PUTコマンド用のカウンタの値を返す.
     pub fn put(&self) -> u64 {
@@ -738,6 +744,7 @@ impl DeviceCommandCounter {
         }
     }
 
+    #[cfg(feature = "device")]
     pub(crate) fn increment(&self, command: &Command) {
         match *command {
             Command::Put { .. } => self.put.increment(),


### PR DESCRIPTION
`device` という名前のフィーチャーを用意して、これが有効な場合のみ device 関連の機能が使えるようにする。
`device` はデフォルトで有効であるため、何もしなければ変更前と挙動は変わらない。

このクレイトで `futures` に依存しているのは `device` 関連の機能だけなので、`device` フィーチャーがオフであれば `futures` には依存しないことができる。これにより、kanils が futures に依存しないようにすることができる。
https://github.com/frugalos/kanils/compare/poc/without-futures