### PR TITLE
Use futures 0.3 and tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ travis-ci = {repository = "frugalos/cannyls"}
 [dependencies]
 adler32 = "1"
 byteorder = { version = "1", features = ["i128"] }
-fibers = "0.1"
-futures = "0.1"
+futures = { version = "0.3" }
 libc = "0.2"
 prometrics = "0.1"
-trackable = "0.2"
+tokio = { version = "1.0", features = ["sync"] }
+trackable = "1.2"
 uuid = { version = "0.7", features = ["v4"] }
 slog = "2"
 
 [dev-dependencies]
-fibers_global = "0.1"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tempdir = "0.3"

--- a/benches/device.rs
+++ b/benches/device.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 extern crate byteorder;
 extern crate cannyls;
-extern crate futures;
 extern crate test;
 #[macro_use]
 extern crate trackable;
@@ -10,50 +9,49 @@ use cannyls::device::DeviceBuilder;
 use cannyls::lump::{LumpData, LumpId};
 use cannyls::nvm::MemoryNvm;
 use cannyls::storage::StorageBuilder;
-use cannyls::{Error, Result};
-use futures::Future;
 use test::Bencher;
 
 fn id(id: usize) -> LumpId {
     LumpId::new(id as u128)
 }
 
-fn wait<F: Future<Error = Error>>(mut f: F) -> Result<()> {
-    while !track!(f.poll())?.is_ready() {}
-    Ok(())
-}
-
 #[bench]
 fn memory_put_small(b: &mut Bencher) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let nvm = MemoryNvm::new(vec![0; 1024 * 1024 * 1024]);
     let storage = track_try_unwrap!(StorageBuilder::new().journal_region_ratio(0.99).create(nvm));
     let device = DeviceBuilder::new().spawn(|| Ok(storage));
     let d = device.handle();
-    let _ = wait(d.request().wait_for_running().list()); // デバイスの起動を待機
+    let _ = runtime.block_on(d.request().wait_for_running().list()); // デバイスの起動を待機
 
     let mut i = 0;
     let data = LumpData::new_embedded("foo".into()).unwrap();
     b.iter(|| {
-        track_try_unwrap!(wait(d.request().put(id(i), data.clone())));
+        track_try_unwrap!(runtime.block_on(d.request().put(id(i), data.clone())));
         i += 1;
     });
 }
 
 #[bench]
 fn memory_put_and_delete_small(b: &mut Bencher) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let nvm = MemoryNvm::new(vec![0; 1024 * 1024 * 1024]);
     let storage = track_try_unwrap!(StorageBuilder::new().journal_region_ratio(0.99).create(nvm));
     let device = DeviceBuilder::new().spawn(|| Ok(storage));
     let d = device.handle();
-    let _ = wait(d.request().wait_for_running().list()); // デバイスの起動を待機
+    let _ = runtime.block_on(d.request().wait_for_running().list()); // デバイスの起動を待機
 
     let mut i = 0;
     let data = LumpData::new_embedded("foo".into()).unwrap();
     b.iter(|| {
         let future0 = d.request().put(id(i), data.clone());
         let future1 = d.request().delete(id(i));
-        track_try_unwrap!(wait(future0));
-        track_try_unwrap!(wait(future1));
+        track_try_unwrap!(runtime.block_on(future0));
+        track_try_unwrap!(runtime.block_on(future1));
         i += 1;
     });
 }

--- a/src/device/builder.rs
+++ b/src/device/builder.rs
@@ -5,9 +5,9 @@ use super::long_queue_policy::LongQueuePolicy;
 use super::thread::DeviceThread;
 use super::{Device, DeviceHandle};
 use crate::nvm::NonVolatileMemory;
-use slog::{Discard, Logger};
 use crate::storage::Storage;
 use crate::Result;
+use slog::{Discard, Logger};
 
 /// `Device`のビルダ.
 #[derive(Debug, Clone)]

--- a/src/device/command.rs
+++ b/src/device/command.rs
@@ -2,7 +2,7 @@
 
 use futures::channel::oneshot;
 use futures::task::{Context, Poll};
-use futures::Future;
+use futures::{Future, FutureExt};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::mpsc::{Receiver, Sender};
@@ -83,7 +83,7 @@ impl<T> AsyncResult<T> {
 impl<T> Future for AsyncResult<T> {
     type Output = Result<T>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        track!(Pin::new(&mut self.0).poll(cx).map(|result| match result {
+        track!(self.0.poll_unpin(cx).map(|result| match result {
             Ok(Ok(x)) => Ok(x),
             Ok(Err(e)) => track!(Err(e)),
             Err(_) => track!(Err(ErrorKind::DeviceTerminated

--- a/src/device/command.rs
+++ b/src/device/command.rs
@@ -1,11 +1,11 @@
 //! デバイスに発行されるコマンド群の定義.
 
 use futures::channel::oneshot;
-use futures::task::{Context, Poll};
 use futures::{Future, FutureExt};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::mpsc::{Receiver, Sender};
+use std::task::{Context, Poll};
 use trackable::error::ErrorKindExt;
 
 use crate::deadline::Deadline;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -11,9 +11,8 @@
 //!
 //! [ストレージ]: ../storage/index.html
 //! [Device]: struct.Device.html
-use futures::future::{FutureExt, TryFutureExt};
 use futures::task::{Context, Poll};
-use futures::Future;
+use futures::{Future, FutureExt, TryFutureExt};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -156,7 +155,7 @@ impl Device {
 impl Future for Device {
     type Output = Result<()>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        let result = track!(Pin::new(&mut self.monitor).poll(cx));
+        let result = track!(self.monitor.poll_unpin(cx));
         if result.is_pending() {
         } else {
             self.is_stopped = true;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -11,10 +11,10 @@
 //!
 //! [ストレージ]: ../storage/index.html
 //! [Device]: struct.Device.html
-use futures::task::{Context, Poll};
 use futures::{Future, FutureExt, TryFutureExt};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 pub use self::builder::DeviceBuilder;
 pub use self::long_queue_policy::LongQueuePolicy;

--- a/src/device/request.rs
+++ b/src/device/request.rs
@@ -8,16 +8,9 @@ use crate::device::command::{self, Command};
 use crate::device::DeviceStatus;
 use crate::lump::{LumpData, LumpHeader, LumpId};
 use crate::storage::StorageUsage;
-use crate::{Error, ErrorKind, Result};
+use crate::{ErrorKind, Result};
 
 /// デバイスに対してリクエストを発行するためのビルダ.
-///
-/// # 注意
-///
-/// リクエストを発行した結果返される`Future`を効率的にポーリングするためには
-/// [`fibers`]を使用する必要がある。
-///
-/// [`fibers`]: https://github.com/dwango/fibers-rs
 #[derive(Debug)]
 pub struct DeviceRequest<'a> {
     device: &'a DeviceThreadHandle,
@@ -49,11 +42,7 @@ impl<'a> DeviceRequest<'a> {
     /// デバイスが管理しているストレージへの書き込み時に、
     /// データをストレージのブロック境界にアライメントするためのメモリコピーが余分に発生してしまう.
     /// それを避けたい場合には、`DeviceHandle::allocate_lump_data`メソッドを使用して`LumpData`を生成すると良い.
-    pub fn put(
-        &self,
-        lump_id: LumpId,
-        lump_data: LumpData,
-    ) -> impl Future<Item = bool, Error = Error> {
+    pub fn put(&self, lump_id: LumpId, lump_data: LumpData) -> impl Future<Output = Result<bool>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
         let (command, response) = command::PutLump::new(
@@ -68,7 +57,7 @@ impl<'a> DeviceRequest<'a> {
     }
 
     /// Lumpを取得する.
-    pub fn get(&self, lump_id: LumpId) -> impl Future<Item = Option<LumpData>, Error = Error> {
+    pub fn get(&self, lump_id: LumpId) -> impl Future<Output = Result<Option<LumpData>>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -78,7 +67,7 @@ impl<'a> DeviceRequest<'a> {
     }
 
     /// Lumpのヘッダを取得する.
-    pub fn head(&self, lump_id: LumpId) -> impl Future<Item = Option<LumpHeader>, Error = Error> {
+    pub fn head(&self, lump_id: LumpId) -> impl Future<Output = Result<Option<LumpHeader>>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -90,7 +79,7 @@ impl<'a> DeviceRequest<'a> {
     /// Lumpを削除する.
     ///
     /// 指定されたlumpが存在した場合には`true`が、しなかった場合には`false`が、結果として返される.
-    pub fn delete(&self, lump_id: LumpId) -> impl Future<Item = bool, Error = Error> {
+    pub fn delete(&self, lump_id: LumpId) -> impl Future<Output = Result<bool>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -104,10 +93,7 @@ impl<'a> DeviceRequest<'a> {
     ///
     /// 返り値のvectorは、引数rangeに含まれるlump idのうち、
     /// 対応するlump dataが存在して実際に削除されたもの全体を表す。
-    pub fn delete_range(
-        &self,
-        range: Range<LumpId>,
-    ) -> impl Future<Item = Vec<LumpId>, Error = Error> {
+    pub fn delete_range(&self, range: Range<LumpId>) -> impl Future<Output = Result<Vec<LumpId>>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -123,7 +109,7 @@ impl<'a> DeviceRequest<'a> {
     ///
     /// 例えば巨大なHDDを使用している場合には、lumpの数が数百万以上になることもあるため、
     /// このメソッドは呼び出す際には注意が必要.
-    pub fn list(&self) -> impl Future<Item = Vec<LumpId>, Error = Error> {
+    pub fn list(&self) -> impl Future<Output = Result<Vec<LumpId>>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -134,10 +120,7 @@ impl<'a> DeviceRequest<'a> {
 
     /// 範囲を指定してlump一覧を取得する.
     ///
-    pub fn list_range(
-        &self,
-        range: Range<LumpId>,
-    ) -> impl Future<Item = Vec<LumpId>, Error = Error> {
+    pub fn list_range(&self, range: Range<LumpId>) -> impl Future<Output = Result<Vec<LumpId>>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 
@@ -148,10 +131,7 @@ impl<'a> DeviceRequest<'a> {
 
     /// 範囲を指定してlump数を取得する.
     ///
-    pub fn usage_range(
-        &self,
-        range: Range<LumpId>,
-    ) -> impl Future<Item = StorageUsage, Error = Error> {
+    pub fn usage_range(&self, range: Range<LumpId>) -> impl Future<Output = Result<StorageUsage>> {
         let deadline = self.deadline.unwrap_or_default();
         let prioritized = self.prioritized;
 

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -1,7 +1,9 @@
-use fibers::sync::oneshot;
-use futures::{Future, Poll};
+use futures::channel::oneshot;
+use futures::task::{Context, Poll};
+use futures::Future;
 use slog::Logger;
 use std::fmt::Debug;
+use std::pin::Pin;
 use std::sync::mpsc as std_mpsc;
 use std::sync::mpsc::{RecvTimeoutError, SendError};
 use std::sync::Arc;
@@ -55,7 +57,7 @@ where
         metrics.status.set(f64::from(DeviceStatus::Starting as u8));
 
         let (command_tx, command_rx) = std_mpsc::channel();
-        let (monitored, monitor) = oneshot::monitor();
+        let (tx, rx) = oneshot::channel();
         let handle = DeviceThreadHandle {
             command_tx: command_tx.clone(),
             metrics: Arc::new(metrics.clone()),
@@ -94,10 +96,10 @@ where
             });
             metrics.status.set(f64::from(DeviceStatus::Stopped as u8));
             metrics.storage = None;
-            monitored.exit(result);
+            let _ = tx.send(result); // ignore error
         });
 
-        (handle, DeviceThreadMonitor(monitor))
+        (handle, DeviceThreadMonitor(rx))
     }
 
     fn run_once(&mut self) -> Result<bool> {
@@ -345,17 +347,17 @@ fn maybe_critical_error<T>(result: &Result<T>) -> Option<Error> {
 
 /// デバイスの実行スレッドの死活監視用オブジェクト.
 #[derive(Debug)]
-pub struct DeviceThreadMonitor(oneshot::Monitor<(), Error>);
+pub struct DeviceThreadMonitor(oneshot::Receiver<Result<()>>);
 impl Future for DeviceThreadMonitor {
-    type Item = ();
-    type Error = Error;
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        track!(self
-            .0
-            .poll()
-            .map_err(|e| e.unwrap_or_else(|| ErrorKind::DeviceTerminated
-                .cause("`DeviceThread` terminated unintentionally")
-                .into())))
+    type Output = Result<()>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        track!(Pin::new(&mut self.0).poll(cx).map(|result| match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => track!(Err(e)),
+            Err(_) => track!(Err(ErrorKind::DeviceTerminated
+                .cause("monitoring channel disconnected")
+                .into())),
+        }))
     }
 }
 

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot;
 use futures::task::{Context, Poll};
-use futures::Future;
+use futures::{Future, FutureExt};
 use slog::Logger;
 use std::fmt::Debug;
 use std::pin::Pin;
@@ -351,7 +351,7 @@ pub struct DeviceThreadMonitor(oneshot::Receiver<Result<()>>);
 impl Future for DeviceThreadMonitor {
     type Output = Result<()>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        track!(Pin::new(&mut self.0).poll(cx).map(|result| match result {
+        track!(self.0.poll_unpin(cx).map(|result| match result {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => track!(Err(e)),
             Err(_) => track!(Err(ErrorKind::DeviceTerminated

--- a/src/device/thread.rs
+++ b/src/device/thread.rs
@@ -1,5 +1,4 @@
 use futures::channel::oneshot;
-use futures::task::{Context, Poll};
 use futures::{Future, FutureExt};
 use slog::Logger;
 use std::fmt::Debug;
@@ -7,6 +6,7 @@ use std::pin::Pin;
 use std::sync::mpsc as std_mpsc;
 use std::sync::mpsc::{RecvTimeoutError, SendError};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::thread;
 use std::time::{Duration, Instant};
 use trackable::error::ErrorKindExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,6 @@
 #![warn(missing_docs)]
 extern crate adler32;
 extern crate byteorder;
-extern crate fibers;
-#[cfg(test)]
-extern crate fibers_global;
 extern crate futures;
 extern crate libc;
 extern crate prometrics;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -28,8 +28,8 @@ use crate::block::BlockSize;
 use crate::lump::{LumpData, LumpDataInner, LumpHeader, LumpId};
 use crate::metrics::StorageMetrics;
 use crate::nvm::NonVolatileMemory;
-use std::ops::Range;
 use crate::Result;
+use std::ops::Range;
 
 mod address;
 mod allocator;


### PR DESCRIPTION
# Benchmark

## futures 0.1 + fibers-rs

```
running 2 tests
test memory_put_and_delete_small ... bench:      15,380 ns/iter (+/- 3,680)
test memory_put_small            ... bench:      12,057 ns/iter (+/- 2,041)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 13.67s

     Running unittests (target/release/deps/storage-d18e21c816692aff)

running 6 tests
test file_put_small                          ... bench:       2,437 ns/iter (+/- 706)
test file_put_small_no_embedded              ... bench:      12,175 ns/iter (+/- 8,190)
test memory_put_and_delete_small             ... bench:         915 ns/iter (+/- 63)
test memory_put_and_delete_small_no_embedded ... bench:       1,094 ns/iter (+/- 65)
test memory_put_and_get_and_delete_small     ... bench:       1,153 ns/iter (+/- 62)
test memory_put_small                        ... bench:         596 ns/iter (+/- 54)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 29.90s
```

## futures 0.3 + tokio

```
running 2 tests
test memory_put_and_delete_small ... bench:      11,058 ns/iter (+/- 2,732)
test memory_put_small            ... bench:      10,839 ns/iter (+/- 4,129)
test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 11.47s
     Running unittests (target/release/deps/storage-832299ce46b7b999)
running 6 tests
test file_put_small                          ... bench:       2,395 ns/iter (+/- 921)
test file_put_small_no_embedded              ... bench:      12,927 ns/iter (+/- 7,392)
test memory_put_and_delete_small             ... bench:         921 ns/iter (+/- 45)
test memory_put_and_delete_small_no_embedded ... bench:       1,096 ns/iter (+/- 38)
test memory_put_and_get_and_delete_small     ... bench:       1,152 ns/iter (+/- 113)
test memory_put_small                        ... bench:         576 ns/iter (+/- 28)
test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out; finished in 26.93s
```